### PR TITLE
Update API and refactoring

### DIFF
--- a/extension/context.cpp
+++ b/extension/context.cpp
@@ -1,33 +1,28 @@
 #include "utils.h"
 
-HL_PRIM vbyte* HL_NAME(create_context)()
+HL_PRIM ImGuiContext* HL_NAME(create_context)()
 {
-	vbyte* ptr = hl_alloc_bytes(sizeof(ImGuiContext*));
-	*(ImGuiContext**)ptr = ImGui::CreateContext(NULL);
-
-	return ptr;
+	return ImGui::CreateContext(NULL);
 }
 
-HL_PRIM void HL_NAME(destroy_context)(vbyte* ptr)
+HL_PRIM void HL_NAME(destroy_context)(ImGuiContext* ptr)
 {
-	ImGuiContext* ctx = ptr == nullptr ? NULL : *(ImGuiContext**)ptr;
-	ImGui::DestroyContext(ctx);
+	ImGui::DestroyContext(ptr);
 }
 
-HL_PRIM vbyte* HL_NAME(get_current_context)()
+HL_PRIM ImGuiContext* HL_NAME(get_current_context)()
 {
-	vbyte* ptr = hl_alloc_bytes(sizeof(ImGuiContext*));
-	*(ImGuiContext**)ptr = ImGui::GetCurrentContext();
-
-	return ptr;
+	return ImGui::GetCurrentContext();
 }
 
-HL_PRIM void HL_NAME(set_current_context)(vbyte* ptr)
+HL_PRIM void HL_NAME(set_current_context)(ImGuiContext* ptr)
 {
-	ImGui::SetCurrentContext(*(ImGuiContext**)ptr);
+	ImGui::SetCurrentContext(ptr);
 }
 
-DEFINE_PRIM(_BYTES, create_context, _NO_ARG);
-DEFINE_PRIM(_VOID, destroy_context, _BYTES);
-DEFINE_PRIM(_BYTES, get_current_context, _NO_ARG);
-DEFINE_PRIM(_VOID, set_current_context, _BYTES);
+#define _TCONTEXT _ABSTRACT(imcontext)
+
+DEFINE_PRIM(_TCONTEXT, create_context, _NO_ARG);
+DEFINE_PRIM(_VOID, destroy_context, _TCONTEXT);
+DEFINE_PRIM(_TCONTEXT, get_current_context, _NO_ARG);
+DEFINE_PRIM(_VOID, set_current_context, _TCONTEXT);

--- a/extension/demo.cpp
+++ b/extension/demo.cpp
@@ -5,14 +5,19 @@ HL_PRIM void HL_NAME(show_demo_window)(bool* p_open)
 	ImGui::ShowDemoWindow(p_open);
 }
 
-HL_PRIM void HL_NAME(show_about_window)(bool* p_open)
-{
-	ImGui::ShowAboutWindow(p_open);
-}
-
 HL_PRIM void HL_NAME(show_metrics_window)(bool* p_open)
 {
 	ImGui::ShowMetricsWindow(p_open);
+}
+
+HL_PRIM void HL_NAME(show_stack_tool_window)(bool* p_open)
+{
+	ImGui:: ShowStackToolWindow(p_open);
+}
+
+HL_PRIM void HL_NAME(show_about_window)(bool* p_open)
+{
+	ImGui::ShowAboutWindow(p_open);
 }
 
 HL_PRIM void HL_NAME(show_style_editor)(vdynamic* hl_style)
@@ -48,8 +53,9 @@ HL_PRIM vbyte* HL_NAME(get_version)()
 }
 
 DEFINE_PRIM(_VOID, show_demo_window, _REF(_BOOL));
-DEFINE_PRIM(_VOID, show_about_window, _REF(_BOOL));
 DEFINE_PRIM(_VOID, show_metrics_window, _REF(_BOOL));
+DEFINE_PRIM(_VOID, show_stack_tool_window, _REF(_BOOL));
+DEFINE_PRIM(_VOID, show_about_window, _REF(_BOOL));
 DEFINE_PRIM(_VOID, show_style_editor, _DYN);
 DEFINE_PRIM(_BOOL, show_style_selector, _STRING);
 DEFINE_PRIM(_VOID, show_font_selector, _STRING);

--- a/extension/dragdrop.cpp
+++ b/extension/dragdrop.cpp
@@ -1,44 +1,127 @@
 #include "utils.h"
 
+static vdynamic* refPayload = nullptr;
+
+inline void clear_gc_payload()
+{
+	if (refPayload != nullptr) {
+		hl_remove_root(refPayload);
+		refPayload = nullptr;
+	}
+}
+
 HL_PRIM bool HL_NAME(begin_drag_drop_target)()
 {
-    return ImGui::BeginDragDropTarget();
+	return ImGui::BeginDragDropTarget();
 }
 
 HL_PRIM void HL_NAME(end_drag_drop_target)()
 {
-    ImGui::EndDragDropTarget();
+	ImGui::EndDragDropTarget();
 }
 
 HL_PRIM bool HL_NAME(begin_drag_drop_source)(ImGuiDragDropFlags* flags)
 {
-    return ImGui::BeginDragDropSource(convertPtr( flags, 0) );
+	return ImGui::BeginDragDropSource(convertPtr( flags, 0) );
 }
 
 HL_PRIM void HL_NAME(end_drag_drop_source)()
 {
-    ImGui::EndDragDropSource();
+	ImGui::EndDragDropSource();
 }
 
 HL_PRIM bool HL_NAME(set_drag_drop_payload)(vstring* type, const char* payload, int len, ImGuiCond* cond)
 {
-    return ImGui::SetDragDropPayload(convertString(type), payload, len, convertPtr(cond, 0 ) );
+	clear_gc_payload();
+	return ImGui::SetDragDropPayload(convertString(type), payload, len, convertPtr(cond, 0 ) );
 }
 
-HL_PRIM const char* HL_NAME(accept_drag_drop_payload)(vstring* type, ImGuiCond* cond)
+HL_PRIM bool HL_NAME(set_drag_drop_payload_object)(vstring* type, vdynamic* payload, ImGuiCond* cond)
 {
-    const ImGuiPayload *payload = ImGui::AcceptDragDropPayload(convertString(type), convertPtr(cond, 0));
-	if( payload != nullptr )
-		return (const char*)payload->Data;
-
-	return nullptr;
+	// Avoid adding payload to gc root multiple times.
+	if (payload != refPayload) {
+		clear_gc_payload();
+		if (payload != nullptr) {
+			refPayload = payload;
+			hl_add_root(payload);
+		}
+	}
+	int data = 0x52454600;
+	return ImGui::SetDragDropPayload(convertString(type), &data, 4, convertPtr(cond, 0 ) );
 }
 
+HL_PRIM ImGuiPayload* HL_NAME(accept_drag_drop_payload)(vstring* type, ImGuiCond* cond)
+{
+	return (ImGuiPayload*)ImGui::AcceptDragDropPayload(convertString(type), convertPtr(cond, 0));
+}
 
+HL_PRIM ImGuiPayload* HL_NAME(get_drag_drop_payload)()
+{
+	return (ImGuiPayload*)ImGui::GetDragDropPayload();
+}
+
+HL_PRIM vdynamic* HL_NAME(get_drag_drop_payload_object)()
+{
+	return refPayload;
+}
+
+HL_PRIM void HL_NAME(dndpayload_clear)(ImGuiPayload* payload)
+{
+	clear_gc_payload();
+	payload->Clear();
+}
+
+HL_PRIM bool HL_NAME(dndpayload_is_data_type)(ImGuiPayload* payload, vstring* type)
+{
+	return payload->IsDataType(convertString(type));
+}
+
+HL_PRIM bool HL_NAME(dndpayload_is_preview)(ImGuiPayload* payload)
+{
+	return payload->IsPreview();
+}
+
+HL_PRIM bool HL_NAME(dndpayload_is_delivery)(ImGuiPayload* payload)
+{
+	return payload->IsDelivery();
+}
+
+HL_PRIM vbyte* HL_NAME(dndpayload_get_binary)(ImGuiPayload* payload)
+{
+	return hl_copy_bytes((vbyte*)payload->Data, payload->DataSize);
+}
+
+HL_PRIM vdynamic* HL_NAME(dndpayload_get_object)(ImGuiPayload* payload, bool clear)
+{
+	if (clear) {
+		vdynamic* prev = refPayload;
+		clear_gc_payload();
+		return prev;
+	}
+	return refPayload;
+}
+
+HL_PRIM void HL_NAME(clear_drag_drop_payload_object)()
+{
+	clear_gc_payload();
+}
+
+#define _TPAYLOAD _ABSTRACT(imdnd)
 
 DEFINE_PRIM(_BOOL, begin_drag_drop_target, _NO_ARG);
 DEFINE_PRIM(_VOID, end_drag_drop_target, _NO_ARG);
 DEFINE_PRIM(_BOOL, begin_drag_drop_source, _REF(_I32));
 DEFINE_PRIM(_VOID, end_drag_drop_source, _NO_ARG);
 DEFINE_PRIM(_BOOL, set_drag_drop_payload, _STRING _BYTES _I32 _REF(_I32) );
-DEFINE_PRIM(_BYTES, accept_drag_drop_payload, _STRING _REF(_I32) );
+DEFINE_PRIM(_BOOL, set_drag_drop_payload_object, _STRING _DYN _REF(_I32));
+DEFINE_PRIM(_TPAYLOAD, accept_drag_drop_payload, _STRING _REF(_I32) );
+DEFINE_PRIM(_TPAYLOAD, get_drag_drop_payload, _NO_ARG);
+DEFINE_PRIM(_DYN, get_drag_drop_payload_object, _NO_ARG);
+
+DEFINE_PRIM(_VOID, dndpayload_clear, _TPAYLOAD);
+DEFINE_PRIM(_BOOL, dndpayload_is_data_type, _TPAYLOAD _STRING);
+DEFINE_PRIM(_BOOL, dndpayload_is_preview, _TPAYLOAD);
+DEFINE_PRIM(_BOOL, dndpayload_is_delivery, _TPAYLOAD);
+DEFINE_PRIM(_BYTES, dndpayload_get_binary, _TPAYLOAD);
+DEFINE_PRIM(_DYN, dndpayload_get_object, _TPAYLOAD _BOOL);
+DEFINE_PRIM(_VOID, clear_drag_drop_payload_object, _NO_ARG);

--- a/extension/drawlist.cpp
+++ b/extension/drawlist.cpp
@@ -1,16 +1,16 @@
 #include "utils.h"
 
-HL_PRIM ImDrawList *HL_NAME(drawlist_get_window_draw_list)()
+HL_PRIM ImDrawList *HL_NAME(get_window_draw_list)()
 {
     return ImGui::GetWindowDrawList();
 }
 
-HL_PRIM ImDrawList *HL_NAME(drawlist_get_foreground_draw_list)()
+HL_PRIM ImDrawList *HL_NAME(get_foreground_draw_list)()
 {
     return ImGui::GetForegroundDrawList();
 }
 
-HL_PRIM ImDrawList *HL_NAME(drawlist_get_background_draw_list)()
+HL_PRIM ImDrawList *HL_NAME(get_background_draw_list)()
 {
     return ImGui::GetBackgroundDrawList();
 }
@@ -157,9 +157,9 @@ HL_PRIM void HL_NAME(drawlist_add_image_rounded)(ImDrawList *drawlist, ImTexture
 
 #define _TDRAWLIST _ABSTRACT(imdrawlist)
 
-DEFINE_PRIM(_TDRAWLIST, drawlist_get_window_draw_list, _NO_ARG );
-DEFINE_PRIM(_TDRAWLIST, drawlist_get_foreground_draw_list, _NO_ARG );
-DEFINE_PRIM(_TDRAWLIST, drawlist_get_background_draw_list, _NO_ARG );
+DEFINE_PRIM(_TDRAWLIST, get_window_draw_list, _NO_ARG );
+DEFINE_PRIM(_TDRAWLIST, get_foreground_draw_list, _NO_ARG );
+DEFINE_PRIM(_TDRAWLIST, get_background_draw_list, _NO_ARG );
 
 DEFINE_PRIM(_VOID, drawlist_push_clip_rect, _TDRAWLIST _DYN _DYN _BOOL);
 DEFINE_PRIM(_VOID, drawlist_push_clip_rect_full_screen, _TDRAWLIST);

--- a/extension/font.cpp
+++ b/extension/font.cpp
@@ -63,6 +63,11 @@ HL_PRIM void HL_NAME(pop_font)()
     ImGui::PopFont();
 }
 
+HL_PRIM ImFont* HL_NAME(get_font)()
+{
+    return ImGui::GetFont();
+}
+
 
 HL_PRIM void HL_NAME(build_font)()
 {
@@ -77,4 +82,5 @@ DEFINE_PRIM(_TFONT, add_font_from_file_ttf, _STRING _F32 _DYN _ARR );
 DEFINE_PRIM(_DYN, get_tex_data_as_rgba32, _NO_ARG);
 DEFINE_PRIM(_VOID, push_font, _TFONT);
 DEFINE_PRIM(_VOID, pop_font, _NO_ARG );
+DEFINE_PRIM(_TFONT, get_font, _NO_ARG);
 DEFINE_PRIM(_VOID, build_font, _NO_ARG );

--- a/extension/id.cpp
+++ b/extension/id.cpp
@@ -5,14 +5,21 @@ HL_PRIM void HL_NAME(push_id)(vstring* str_id)
 	ImGui::PushID(unicodeToUTF8(str_id).c_str());
 }
 
-HL_PRIM void HL_NAME(push_id2)(vstring* str_id_begin, vstring* str_id_end)
+HL_PRIM void HL_NAME(push_id_sub)(vstring* str_id, int begin, int end)
 {
-	ImGui::PushID(unicodeToUTF8(str_id_begin).c_str(), unicodeToUTF8(str_id_end).c_str());
+	// Likely will break if contains real UTF, but at least it works compared to old implementation.
+	auto str = unicodeToUTF8(str_id).c_str();
+	if (end > str_id->length) end = str_id->length;
+	ImGui::PushID(str + begin, str + end);
 }
 
-HL_PRIM void HL_NAME(push_id3)(int int_id)
+HL_PRIM void HL_NAME(push_id_int)(int int_id)
 {
 	ImGui::PushID(int_id);
+}
+
+HL_PRIM void HL_NAME(push_id_ptr)(vobj* ptr_id) {
+	ImGui::PushID((void*)ptr_id);
 }
 
 HL_PRIM void HL_NAME(pop_id)()
@@ -25,14 +32,23 @@ HL_PRIM ImGuiID HL_NAME(get_id)(vstring* str_id)
 	return ImGui::GetID(unicodeToUTF8(str_id).c_str());
 }
 
-HL_PRIM ImGuiID HL_NAME(get_id2)(vstring* str_id_begin, vstring* str_id_end)
+HL_PRIM ImGuiID HL_NAME(get_id_sub)(vstring* str_id, int begin, int end)
 {
-	return ImGui::GetID(unicodeToUTF8(str_id_begin).c_str(), unicodeToUTF8(str_id_end).c_str());
+	auto str = unicodeToUTF8(str_id).c_str();
+	if (end > str_id->length) end = str_id->length;
+	return ImGui::GetID(str + begin, str + end);
 }
 
+HL_PRIM ImGuiID HL_NAME(get_id_ptr)(vobj* ptr_id) {
+	return ImGui::GetID((void*)ptr_id);
+}
+
+
 DEFINE_PRIM(_VOID, push_id, _STRING);
-DEFINE_PRIM(_VOID, push_id2, _STRING _STRING);
-DEFINE_PRIM(_VOID, push_id3, _I32);
+DEFINE_PRIM(_VOID, push_id_sub, _STRING _I32 _I32);
+DEFINE_PRIM(_VOID, push_id_int, _I32);
+DEFINE_PRIM(_VOID, push_id_ptr, _DYN);
 DEFINE_PRIM(_VOID, pop_id, _NO_ARG);
 DEFINE_PRIM(_I32, get_id, _STRING);
-DEFINE_PRIM(_I32, get_id2, _STRING _STRING);
+DEFINE_PRIM(_I32, get_id_sub, _STRING _I32 _I32);
+DEFINE_PRIM(_I32, get_id_ptr, _DYN);

--- a/extension/id.cpp
+++ b/extension/id.cpp
@@ -2,13 +2,13 @@
 
 HL_PRIM void HL_NAME(push_id)(vstring* str_id)
 {
-	ImGui::PushID(unicodeToUTF8(str_id).c_str());
+	ImGui::PushID(convertString(str_id));
 }
 
 HL_PRIM void HL_NAME(push_id_sub)(vstring* str_id, int begin, int end)
 {
 	// Likely will break if contains real UTF, but at least it works compared to old implementation.
-	auto str = unicodeToUTF8(str_id).c_str();
+	auto str = convertString(str_id);
 	if (end > str_id->length) end = str_id->length;
 	ImGui::PushID(str + begin, str + end);
 }
@@ -29,12 +29,12 @@ HL_PRIM void HL_NAME(pop_id)()
 
 HL_PRIM ImGuiID HL_NAME(get_id)(vstring* str_id)
 {
-	return ImGui::GetID(unicodeToUTF8(str_id).c_str());
+	return ImGui::GetID(convertString(str_id));
 }
 
 HL_PRIM ImGuiID HL_NAME(get_id_sub)(vstring* str_id, int begin, int end)
 {
-	auto str = unicodeToUTF8(str_id).c_str();
+	auto str = convertString(str_id);
 	if (end > str_id->length) end = str_id->length;
 	return ImGui::GetID(str + begin, str + end);
 }

--- a/extension/popup.cpp
+++ b/extension/popup.cpp
@@ -2,7 +2,7 @@
 
 HL_PRIM void HL_NAME(open_popup)(vstring* str_id)
 {
-    ImGui::OpenPopup(unicodeToUTF8(str_id).c_str());
+    ImGui::OpenPopup(convertString(str_id));
 }
 
 HL_PRIM bool HL_NAME(begin_popup)(vstring* str_id, ImGuiWindowFlags* flags)

--- a/extension/tab.cpp
+++ b/extension/tab.cpp
@@ -20,6 +20,11 @@ HL_PRIM void HL_NAME(end_tab_item)()
     ImGui::EndTabItem();
 }
 
+HL_PRIM bool HL_NAME(tab_item_button)(vstring* label, ImGuiTabItemFlags* flags)
+{
+    return ImGui::TabItemButton(convertString(label), convertPtr(flags, 0));
+}
+
 HL_PRIM void HL_NAME(set_tab_item_closed)(vstring* tab_or_docked_window_label)
 {
     ImGui::SetTabItemClosed(convertString(tab_or_docked_window_label));
@@ -29,4 +34,5 @@ DEFINE_PRIM(_BOOL, begin_tab_bar, _STRING _REF(_I32));
 DEFINE_PRIM(_VOID, end_tab_bar, _NO_ARG);
 DEFINE_PRIM(_BOOL, begin_tab_item, _STRING _REF(_BOOL) _REF(_I32));
 DEFINE_PRIM(_VOID, end_tab_item, _NO_ARG);
+DEFINE_PRIM(_BOOL, tab_item_button, _STRING _REF(_I32));
 DEFINE_PRIM(_VOID, set_tab_item_closed, _STRING);

--- a/extension/widgets_listbox.cpp
+++ b/extension/widgets_listbox.cpp
@@ -16,9 +16,9 @@ HL_PRIM bool HL_NAME(list_box)(vstring* label, int* current_item, varray* items,
     return ImGui::ListBox(convertString(label), current_item, &cstr_items[0], convertPtr(height_in_items, -1));
 }
 
-HL_PRIM bool HL_NAME(list_box_header)(vstring* label, vdynamic* size)
+HL_PRIM bool HL_NAME(begin_list_box)(vstring* label, vdynamic* size)
 {
-    return ImGui::ListBoxHeader(convertString(label), getImVec2(size));
+    return ImGui::BeginListBox(convertString(label), getImVec2(size));
 }
 
 HL_PRIM bool HL_NAME(list_box_header2)(vstring* label, int items_count, int* height_in_items)
@@ -26,12 +26,12 @@ HL_PRIM bool HL_NAME(list_box_header2)(vstring* label, int items_count, int* hei
     return ImGui::ListBoxHeader(convertString(label), items_count, convertPtr(height_in_items, -1));
 }
 
-HL_PRIM void HL_NAME(list_box_footer)()
+HL_PRIM void HL_NAME(end_list_box)()
 {
-    ImGui::ListBoxFooter();
+    ImGui::EndListBox();
 }
 
 DEFINE_PRIM(_BOOL, list_box, _STRING _REF(_I32) _ARR _REF(_I32));
-DEFINE_PRIM(_BOOL, list_box_header, _STRING _DYN);
+DEFINE_PRIM(_BOOL, begin_list_box, _STRING _DYN);
 DEFINE_PRIM(_BOOL, list_box_header2, _STRING _I32 _REF(_I32));
-DEFINE_PRIM(_VOID, list_box_footer, _NO_ARG);
+DEFINE_PRIM(_VOID, end_list_box, _NO_ARG);

--- a/extension/widgets_main.cpp
+++ b/extension/widgets_main.cpp
@@ -2,22 +2,22 @@
 
 HL_PRIM bool HL_NAME(button)(vstring* label, vdynamic* size)
 {
-	return ImGui::Button(unicodeToUTF8(label).c_str(), getImVec2(size));
+	return ImGui::Button(convertString(label), getImVec2(size));
 }
 
 HL_PRIM bool HL_NAME(small_button)(vstring* label)
 {
-	return ImGui::SmallButton(unicodeToUTF8(label).c_str());
+	return ImGui::SmallButton(convertString(label));
 }
 
 HL_PRIM bool HL_NAME(invisible_button)(vstring* str_id, vdynamic* size)
 {
-	return ImGui::InvisibleButton(unicodeToUTF8(str_id).c_str(), getImVec2(size));
+	return ImGui::InvisibleButton(convertString(str_id), getImVec2(size));
 }
 
 HL_PRIM bool HL_NAME(arrow_button)(vstring* str_id, ImGuiDir dir)
 {
-	return ImGui::ArrowButton(unicodeToUTF8(str_id).c_str(), dir);
+	return ImGui::ArrowButton(convertString(str_id), dir);
 }
 
 HL_PRIM void HL_NAME(image)(ImTextureID user_texture_id, vdynamic* size, vdynamic* uv0, vdynamic* uv1, vdynamic* tint_col, vdynamic* border_col)
@@ -45,27 +45,27 @@ HL_PRIM bool HL_NAME(image_button)(ImTextureID user_texture_id, vdynamic* size, 
 
 HL_PRIM bool HL_NAME(checkbox)(vstring* label, bool* v)
 {
-	return ImGui::Checkbox(unicodeToUTF8(label).c_str(), v);
+	return ImGui::Checkbox(convertString(label), v);
 }
 
 HL_PRIM bool HL_NAME(checkbox_flags)(vstring* label, unsigned int* flags, unsigned int flags_value)
 {
-	return ImGui::CheckboxFlags(unicodeToUTF8(label).c_str(), flags, flags_value);
+	return ImGui::CheckboxFlags(convertString(label), flags, flags_value);
 }
 
 HL_PRIM bool HL_NAME(radio_button)(vstring* label, bool active)
 {
-	return ImGui::RadioButton(unicodeToUTF8(label).c_str(), active);
+	return ImGui::RadioButton(convertString(label), active);
 }
 
 HL_PRIM bool HL_NAME(radio_button2)(vstring* label, int* v, int v_button)
 {
-	return ImGui::RadioButton(unicodeToUTF8(label).c_str(), v, v_button);
+	return ImGui::RadioButton(convertString(label), v, v_button);
 }
 
 HL_PRIM void HL_NAME(progress_bar)(float fraction, vdynamic* size_arg, vstring* overlay)
 {
-	ImGui::ProgressBar(fraction, getImVec2(size_arg, ImVec2(-1, 0)), overlay != nullptr ? unicodeToUTF8(overlay).c_str() : NULL);
+	ImGui::ProgressBar(fraction, getImVec2(size_arg, ImVec2(-1, 0)), convertString(overlay));
 }
 
 HL_PRIM void HL_NAME(bullet)()

--- a/extension/widgets_value.cpp
+++ b/extension/widgets_value.cpp
@@ -1,4 +1,5 @@
 #include "utils.h"
+#include "lib/imgui/imgui_internal.h"
 
 HL_PRIM void HL_NAME(value_bool)(vstring* prefix, bool b)
 {
@@ -15,6 +16,21 @@ HL_PRIM void HL_NAME(value_single)(vstring* prefix, float v, vstring* float_form
     ImGui::Value(convertString(prefix), v, convertString(float_format));
 }
 
+HL_PRIM void HL_NAME(value_double)(vstring* prefix, double v, vstring* double_format)
+{
+    if (double_format != NULL)
+    {
+        char fmt[64];
+        ImFormatString(fmt, IM_ARRAYSIZE(fmt), "%%s: %s", convertString(double_format));
+        ImGui::Text(fmt, prefix, v);
+    }
+    else
+    {
+        ImGui::Text("%s: %.3lf", prefix, v);
+    }
+}
+
 DEFINE_PRIM(_VOID, value_bool, _STRING _BOOL);
 DEFINE_PRIM(_VOID, value_int, _STRING _I32);
 DEFINE_PRIM(_VOID, value_single, _STRING _F32 _STRING);
+DEFINE_PRIM(_VOID, value_double, _STRING _F64 _STRING);

--- a/extension/windows_utilities.cpp
+++ b/extension/windows_utilities.cpp
@@ -20,6 +20,10 @@ HL_PRIM bool HL_NAME(is_window_hovered)(ImGuiFocusedFlags* flags)
 	return ImGui::IsWindowHovered(convertPtr(flags, 0));
 }
 
+HL_PRIM float HL_NAME(get_window_dpi_scale)() {
+	return ImGui::GetWindowDpiScale();
+}
+
 HL_PRIM vdynamic* HL_NAME(get_window_pos)()
 {
 	return getHLFromImVec2(ImGui::GetWindowPos());
@@ -124,6 +128,7 @@ DEFINE_PRIM(_BOOL, is_window_appearing, _NO_ARG);
 DEFINE_PRIM(_BOOL, is_window_collapsed, _NO_ARG);
 DEFINE_PRIM(_BOOL, is_window_focused, _REF(_I32));
 DEFINE_PRIM(_BOOL, is_window_hovered, _REF(_I32));
+DEFINE_PRIM(_F32, get_window_dpi_scale, _NO_ARG);
 DEFINE_PRIM(_DYN, get_window_pos, _NO_ARG);
 DEFINE_PRIM(_DYN, get_window_size, _NO_ARG);
 DEFINE_PRIM(_F32, get_window_width, _NO_ARG);

--- a/extension/windows_utilities.cpp
+++ b/extension/windows_utilities.cpp
@@ -106,22 +106,22 @@ HL_PRIM void HL_NAME(set_window_font_scale)(float scale)
 
 HL_PRIM void HL_NAME(set_window_pos2)(vstring* name, vdynamic* pos, ImGuiCond* cond)
 {
-	ImGui::SetWindowPos(unicodeToUTF8(name).c_str(), getImVec2(pos), convertPtr(cond, 0));
+	ImGui::SetWindowPos(convertString(name), getImVec2(pos), convertPtr(cond, 0));
 }
 
 HL_PRIM void HL_NAME(set_window_size2)(vstring* name, vdynamic* size, ImGuiCond* cond)
 {
-	ImGui::SetWindowSize(unicodeToUTF8(name).c_str(), getImVec2(size), convertPtr(cond, 0));
+	ImGui::SetWindowSize(convertString(name), getImVec2(size), convertPtr(cond, 0));
 }
 
 HL_PRIM void HL_NAME(set_window_collapsed2)(vstring* name, bool collapsed, ImGuiCond* cond)
 {
-	ImGui::SetWindowCollapsed(unicodeToUTF8(name).c_str(), collapsed, convertPtr(cond, 0));
+	ImGui::SetWindowCollapsed(convertString(name), collapsed, convertPtr(cond, 0));
 }
 
 HL_PRIM void HL_NAME(set_window_focus2)(vstring* name)
 {
-	ImGui::SetWindowFocus(unicodeToUTF8(name).c_str());
+	ImGui::SetWindowFocus(convertString(name));
 }
 
 DEFINE_PRIM(_BOOL, is_window_appearing, _NO_ARG);

--- a/imgui/ImGui.hx
+++ b/imgui/ImGui.hx
@@ -803,6 +803,7 @@ class ImGui
 	public static function setCurrentContext(ctx : ImContextPtr) {}
 
 	// Main
+	// TODO: GetIO()
 	public static function getStyle() : ExtDynamic<ImGuiStyle> {return null;}
 	public static function setStyle(style : ExtDynamic<ImGuiStyle>) {}
 	public static function newFrame() {}
@@ -823,25 +824,26 @@ class ImGui
 		return @:privateAccess String.fromUTF8(get_version());
 	}
 
-	// styles
+	// Styles
 	public static function styleColorsDark(style : ExtDynamic<ImGuiStyle> = null) {}
 	public static function styleColorsClassic(style : ExtDynamic<ImGuiStyle> = null) {}
 	public static function styleColorsLight(style : ExtDynamic<ImGuiStyle> = null) {}
 
-	// windows
+	// Windows
 	public static function begin(name : String, open : hl.Ref<Bool> = null, flags : ImGuiWindowFlags = 0) : Bool {return false;}
 	public static function end() {}
 
-	// Child windows
+	// Child Windows
 	public static function beginChild(str_id : String, size : ExtDynamic<ImVec2> = null, border : Bool = false, flags : ImGuiWindowFlags = 0) : Bool {return false;}
 	public static function beginChild2(id : Int, size : ExtDynamic<ImVec2> = null, border : Bool = false, flags : ImGuiWindowFlags = 0) : Bool {return false;}
 	public static function endChild() {}
 
-	// Windows utilities
+	// Windows Utilities
 	public static function isWindowAppearing() : Bool {return false;}
 	public static function isWindowCollapsed() : Bool {return false;}
 	public static function isWindowFocused(flags : ImGuiFocusedFlags = 0) {return false;}
 	public static function isWindowHovered(flags : ImGuiFocusedFlags = 0) {return false;}
+	public static function getWindowDrawList() : ImDrawList {return null;}
 	public static function getWindowDpiScale(): Single { return 0; }
 	public static function getWindowPos() : ExtDynamic<ImVec2> {return null;}
 	public static function getWindowSize() : ExtDynamic<ImVec2> {return null;}
@@ -865,26 +867,6 @@ class ImGui
 	public static function setWindowSize2(name : String, size : ExtDynamic<ImVec2>, cond : ImGuiCond = 0) {}
 	public static function setWindowCollapsed2(name : String, collapsed : Bool, cond : ImGuiCond = 0) {}
 	public static function setWindowFocus2(name : String) {}
-
-	// Docking
-	public static function dockSpace(id : ImGuiID, size : ExtDynamic<ImVec2> = null, flags : ImGuiDockNodeFlags = 0) {}
-	public static function setNextWindowDockId(id : ImGuiID, cond : ImGuiCond = 0) {}
-	public static function getWindowDockId() : ImGuiID { return 0; }
-	public static function isWindowDocked() : Bool { return false; }
-
-	// Dock Builder
-	public static function dockBuilderDockWindow(window_name: String, node_id : ImGuiID) {}
-	public static function dockBuilderGetNode(node_id : ImGuiID) : ImGuiDockNode { return null; }
-	public static function dockBuilderGetCentralNode(node_id : ImGuiID) : ImGuiDockNode { return null; }
-	public static function dockBuilderAddNode(node_id : ImGuiID, flags: ImGuiDockNodeFlags) : ImGuiID { return 0; }
-	public static function dockBuilderRemoveNode(node_id : ImGuiID) {}
-	public static function dockBuilderRemoveNodeDockedWindows(node_id : ImGuiID, clear_settings_refs: Bool) {}
-	public static function dockBuilderRemoveNodeChildNodes(node_id : ImGuiID) {}
-	public static function dockBuilderSetNodePos(node_id : ImGuiID, pos: ExtDynamic<ImVec2> ) {}
-	public static function dockBuilderSetNodeSize(node_id : ImGuiID, size: ExtDynamic<ImVec2> ) {}
-	public static function dockBuilderSplitNode(node_id : ImGuiID, split_dir: ImGuiDir, size_ratio_for_node_at_dir: Single, out_id_at_dir: hl.Ref<ImGuiID>, out_id_at_opposite_dir: hl.Ref<ImGuiID> ) { return 0; }
-	public static function dockBuilderCopyWindowSettings(src_name: String, dst_name: String) {}
-	public static function dockBuilderFinish(node_id : ImGuiID) {}
 
 	// Content region
 	public static function getContentRegionMax() : ExtDynamic<ImVec2> {return null;}
@@ -1016,7 +998,7 @@ class ImGui
 	public static function combo2(label : String, current_item : hl.Ref<Int>, items_separated_by_zeros : String, popup_max_height_in_items : Int = -1) : Bool {return false;}
 	// TODO: comboCallback variant
 
-	// Widgets: Drags
+	// Widgets: Drag Sliders
 	public static function dragFloat(label : String, v : hl.Ref<Single>, v_speed : Single = 1.0, v_min : Single = 0.0, v_max : Single = 0.0, format : String = "%.3f", flags : ImGuiSliderFlags = 0) : Bool {return false;}
 	public static function dragInt(label : String, v : hl.Ref<Int>, v_speed : Single = 1.0, v_min : Int = 0, v_max : Int = 0, format : String = "%d", flags : ImGuiSliderFlags = 0) : Bool {return false;}
 	public static function dragDouble(label : String, v : hl.Ref<Float>, v_speed : Single = 1.0, v_min : Float = 0.0, v_max : Float = 0.0, format : String = "%.3lf", flags : ImGuiSliderFlags = 0) : Bool {return false;}
@@ -1035,7 +1017,7 @@ class ImGui
 	}
 	static function drag_scalar_n(label : String, type : Int, v : hl.NativeArray<Dynamic>, v_speed : Single, v_min : Dynamic, v_max : Dynamic, format : String, flags : Int) : Bool {return false;}
 
-	// Widgets: Sliders
+	// Widgets: Regular Sliders
 	public static function sliderFloat(label : String, v : hl.Ref<Single>, v_min : Single, v_max : Single, format : String = "%.3f", flags : ImGuiSliderFlags = 0) : Bool {return false;}
 	public static function sliderInt(label : String, v : hl.Ref<Int>, v_min : Int, v_max : Int, format : String = "%d", flags : ImGuiSliderFlags = 0) : Bool {return false;}
 	public static function sliderDouble(label : String, v : hl.Ref<Float>, v_min : Float, v_max : Float, format : String = "%.3lf", flags : ImGuiSliderFlags = 0) : Bool {return false;}
@@ -1130,16 +1112,16 @@ class ImGui
 	**/
 	public static function beginListBox(label: String, size: ExtDynamic<ImVec2> = null): Bool { return false; }
 	/** Only call if beginListBox returns true! **/
-	public static function endListBox(): Bool { return false; }
+	public static function endListBox() {}
 	
 	public static function listBox(label : String, current_item : hl.Ref<Int>, items : hl.NativeArray<String>, height_in_items : Int = -1) : Bool {return false;}
 	// TODO: Callback variant
 	@:deprecated("Use beginListBox")
-	public static function listBoxHeader(label : String, size : ExtDynamic<ImVec2> = null) : Bool {return beginListBox(label, size);}
+	public static inline function listBoxHeader(label : String, size : ExtDynamic<ImVec2> = null) : Bool {return beginListBox(label, size);}
 	@:deprecated("Obsolete")
 	public static function listBoxHeader2(label : String, items_count : Int, height_in_items : Int = -1) : Bool {return false;}
 	@:deprecated("Use endListBox")
-	public static function listBoxFooter() {}
+	public static inline function listBoxFooter() { endListBox(); }
 
 	// Widgets: Data Plotting
     public static function plotLines(label : String, values : hl.NativeArray<Single>, values_offset : Int = 0, overlay_text : String = null, scale_min : Single = FLT_MAX, scale_max : Single = FLT_MAX, graph_size : ExtDynamic<ImVec2>) {}
@@ -1190,27 +1172,23 @@ class ImGui
 	// Popups: query functions
 	public static function isPopupOpen(str_id : String) : Bool {return false;}
 
-    // Columns
-    public static function columns(count : Int = 1, id : String = null, border : Bool = true) {}
-    public static function nextColumn() {}
-    public static function getColumnIndex() : Int {return 0;}
-    public static function getColumnWidth(column_index : Int = -1) : Single {return 0;}
-    public static function setColumnWidth(column_index : Int, width : Single) {}
-    public static function getColumnOffset(column_index : Int = -1) : Single {return 0;}
-    public static function setColumnOffset(column_index : Int, offset_x : Single) {}
-	public static function getColumnsCount() : Int {return 0;}
-
 	// Tables
 	public static function beginTable( id: String, column: Int, flags: ImGuiTableFlags = ImGuiTableFlags.None, outer_size: ExtDynamic<ImVec2> = null, inner_width = 0 ): Bool { return false; }
 	public static function endTable() {}
 	public static function tableNextRow( rowFlags: ImGuiTableRowFlags = ImGuiTableRowFlags.None, minRowHeight: Single = 0 ) {}
 	public static function tableNextColumn() {}
 	public static function tableSetColumnIndex( columnIndex: Int ) {}
+	
+	// Tables: Headers & Columns declaration
 	public static function tableSetupColumn( id: String, flags: ImGuiTableColumnFlags = ImGuiTableColumnFlags.None, initWidthOrHeight: Single = 0, userId: ImGuiID = 0) {}
 	public static function tableSetupScrollFreeze( cols: Int, rows: Int ) {}
 	public static function tableHeadersRow() {}
 	public static function tableHeader( id: String ) {}
+	
+	// Tables: Sorting
 	//public static function tableGetSortSpecs( id: String ): ImGUiTableSortSpecs { return null } // @todo
+	
+	// Tables: Miscellaneous functions
 	public static function tableGetColumnCount(): Int { return 0; }
 	public static function tableGetColumnIndex(): Int { return 0; }
 	public static function tableGetRowIndex(): Int { return 0; }
@@ -1219,6 +1197,15 @@ class ImGui
 	public static function tableSetColumnEnabled( column_n: Int, enabled: Bool ): Void {}
 	public static function tableSetBGColor( target: ImGuiTableBgTarget, color: Int, column_n: Int = -1 ): Void { }
 
+	// Legacy Columns API (prefer using Tables!)
+	public static function columns(count : Int = 1, id : String = null, border : Bool = true) {}
+	public static function nextColumn() {}
+	public static function getColumnIndex() : Int {return 0;}
+	public static function getColumnWidth(column_index : Int = -1) : Single {return 0;}
+	public static function setColumnWidth(column_index : Int, width : Single) {}
+	public static function getColumnOffset(column_index : Int = -1) : Single {return 0;}
+	public static function setColumnOffset(column_index : Int, offset_x : Single) {}
+	public static function getColumnsCount() : Int {return 0;}
 
 	// Tab Bars, Tabs
 	public static function beginTabBar(str_id : String, flags : ImGuiTabBarFlags = 0) : Bool {return false;}
@@ -1228,6 +1215,30 @@ class ImGui
 	public static function tabItemButton(label : String, flags : ImGuiTabItemFlags = 0) : Bool {return false;}
 	public static function setTabItemClosed(tab_or_docked_window_label : String) {}
 
+	// Docking
+	public static function dockSpace(id : ImGuiID, size : ExtDynamic<ImVec2> = null, flags : ImGuiDockNodeFlags = 0) {}
+	// dockSpaceOverViewport // Viewport API
+	public static function setNextWindowDockId(id : ImGuiID, cond : ImGuiCond = 0) {}
+	// setNextWindowClass // Viewport API
+	public static function getWindowDockId() : ImGuiID { return 0; }
+	public static function isWindowDocked() : Bool { return false; }
+
+	// [imgui_internal] Dock Builder
+	public static function dockBuilderDockWindow(window_name: String, node_id : ImGuiID) {}
+	public static function dockBuilderGetNode(node_id : ImGuiID) : ImGuiDockNode { return null; }
+	public static function dockBuilderGetCentralNode(node_id : ImGuiID) : ImGuiDockNode { return null; }
+	public static function dockBuilderAddNode(node_id : ImGuiID, flags: ImGuiDockNodeFlags) : ImGuiID { return 0; }
+	public static function dockBuilderRemoveNode(node_id : ImGuiID) {}
+	public static function dockBuilderRemoveNodeDockedWindows(node_id : ImGuiID, clear_settings_refs: Bool) {}
+	public static function dockBuilderRemoveNodeChildNodes(node_id : ImGuiID) {}
+	public static function dockBuilderSetNodePos(node_id : ImGuiID, pos: ExtDynamic<ImVec2> ) {}
+	public static function dockBuilderSetNodeSize(node_id : ImGuiID, size: ExtDynamic<ImVec2> ) {}
+	public static function dockBuilderSplitNode(node_id : ImGuiID, split_dir: ImGuiDir, size_ratio_for_node_at_dir: Single, out_id_at_dir: hl.Ref<ImGuiID>, out_id_at_opposite_dir: hl.Ref<ImGuiID> ) { return 0; }
+	// DockBuilderCopyDockSpace
+	// DockBuilderCopyNode
+	public static function dockBuilderCopyWindowSettings(src_name: String, dst_name: String) {}
+	public static function dockBuilderFinish(node_id : ImGuiID) {}
+
 	// Logging/Capture
 	public static function logToTTY(auto_open_depth : Int = -1) {}
 	public static function logToFile(auto_open_depth : Int = -1, filename : String = null) {}
@@ -1236,80 +1247,6 @@ class ImGui
 	public static function logButtons() {}
 	public static function logText(text : String) {} // TODO: Allow format args
 
-    // Clipping
-    public static function pushClipRect(clip_rect_min : ExtDynamic<ImVec2>, clip_rect_max : ExtDynamic<ImVec2>, intersect_with_current_clip_rect : Bool) {}
-    public static function popClipRect() {}
-
-    // Focus, Activation
-    public static function setItemDefaultFocus() {}
-	public static function setKeyboardFocusHere(offset : Int = 0) {}
-
-	// Item/Widgets Utilities
-    public static function isItemHovered(flags : ImGuiHoveredFlags = 0) : Bool {return false;}
-    public static function isItemActive() : Bool {return false;}
-    public static function isItemFocused() : Bool {return false;}
-    public static function isItemClicked(mouse_button : ImGuiMouseButton = 0) : Bool {return false;}
-    public static function isItemVisible() : Bool {return false;}
-    public static function isItemEdited() : Bool {return false;}
-    public static function isItemActivated() : Bool {return false;}
-    public static function isItemDeactivated() : Bool {return false;}
-    public static function isItemDeactivatedAfterEdit() : Bool {return false;}
-    public static function isItemToggledOpen() : Bool {return false;}
-    public static function isAnyItemHovered() : Bool {return false;}
-    public static function isAnyItemActive() : Bool {return false;}
-    public static function isAnyItemFocused() : Bool {return false;}
-    public static function getItemRectMin() : ExtDynamic<ImVec2> {return null;}
-    public static function getItemRectMax() : ExtDynamic<ImVec2> {return null;}
-    public static function getItemRectSize() : ExtDynamic<ImVec2> {return null;}
-    public static function setItemAllowOverlap() {}
-
-    // Miscellaneous Utilities
-    public static function isRectVisible(size : ExtDynamic<ImVec2>) : Bool {return false;}
-    public static function isRectVisible2(rect_min : ExtDynamic<ImVec2>, rect_max : ExtDynamic<ImVec2>) : Bool {return false;}
-    public static function getTime() : Float {return 0;}
-    public static function getFrameCount() : Int {return 0;}
-	static function get_style_color_name(idx : ImGuiCol) : hl.Bytes {return null;}
-    public static function getStyleColorName(idx : ImGuiCol) : String {
-		return @:privateAccess String.fromUTF8(get_style_color_name(idx));
-	}
-    public static function calcListClipping(items_count : Int, items_height : Single, out_items_display_start : hl.Ref<Int>, out_items_display_end : hl.Ref<Int>) {}
-    public static function beginChildFrame(id : ImGuiID, size : ExtDynamic<ImVec2>, flags : ImGuiWindowFlags = 0) : Bool {return false;}
-	public static function endChildFrame() {}
-
-	// Text Utilities
-	public static function calcTextSize(text : String, text_end : String = null, hide_text_after_double_hash : Bool = false, wrap_width : Single = -1.0) : ExtDynamic<ImVec2> {return null;}
-
-    // Color Utilities
-    public static function colorConvertU32ToFloat4(color : ImU32) : ExtDynamic<ImVec4> {return null;}
-    public static function colorConvertFloat4ToU32(color : ExtDynamic<ImVec4>) : ImU32 {return 0;}
-    public static function colorConvertRGBtoHSV(r : Single, g : Single, b : Single, out_h : hl.Ref<Single>, out_s : hl.Ref<Single>, out_v : hl.Ref<Single>) {}
-    public static function colorConvertHSVtoRGB(h : Single, s : Single, v : Single, out_r : hl.Ref<Single>, out_g : hl.Ref<Single>, out_b : hl.Ref<Single>) {}
-
-    // Inputs Utilities: Keyboard
-    public static function getKeyIndex(imgui_key : ImGuiKey) : Int {return 0;}
-    public static function isKeyDown(user_key_index : Int) : Bool {return false;}
-    public static function isKeyPressed(user_key_index : Int, repeat : Bool = true) : Bool {return false;}
-    public static function isKeyReleased(user_key_index : Int) : Bool {return false;}
-    public static function getKeyPressedAmount(key_index : Int, repeat_delay : Single, rate : Single) : Int {return 0;}
-    public static function captureKeyboardFromApp(want_capture_keyboard_value : Bool = true) {}
-
-    // Inputs Utilities: Mouse
-    public static function isMouseDown(button : ImGuiMouseButton) : Bool {return false;}
-    public static function isMouseClicked(button : ImGuiMouseButton, repeat : Bool = false) : Bool {return false;}
-    public static function isMouseReleased(button : ImGuiMouseButton) : Bool {return false;}
-    public static function isMouseDoubleClicked(button : ImGuiMouseButton) : Bool {return false;}
-    public static function isMouseHoveringRect(r_min : ExtDynamic<ImVec2>, r_max : ExtDynamic<ImVec2>, clip : Bool = true) : Bool {return false;}
-    public static function isMousePosValid(mouse_pos : ExtDynamic<ImVec2> = null) : Bool {return false;}
-    public static function isAnyMouseDown() : Bool {return false;}
-    public static function getMousePos() : ExtDynamic<ImVec2> {return null;}
-    public static function getMousePosOnOpeningCurrentPopup() : ExtDynamic<ImVec2> {return null;}
-    public static function isMouseDragging(button : ImGuiMouseButton, lock_threshold : Single = -1.0) : Bool {return false;}
-    public static function getMouseDragDelta(button : ImGuiMouseButton = 0, lock_threshold : Single = -1.0) : ExtDynamic<ImVec2> {return null;}
-    public static function resetMouseDragDelta(button : ImGuiMouseButton = 0) {}
-    public static function getMouseCursor() : ImGuiMouseCursor {return 0;}
-    public static function setMouseCursor(cursor_type : ImGuiMouseCursor) {}
-    public static function captureMouseFromApp(want_capture_mouse_value : Bool = true) {}
-
 	// Drag and drop
 	public static function beginDragDropTarget(): Bool { return false; }
 	public static function endDragDropTarget() {}
@@ -1317,6 +1254,114 @@ class ImGui
 	public static function endDragDropSource() {}
 	public static function setDragDropPayload(type: String, payload: hl.Bytes, length: Int, cond: ImGuiCond = 0 ) : Bool { return false; }
 	public static function acceptDragDropPayload(type: String, cond: ImGuiCond = 0 ) : hl.Bytes { return null; }
+
+	// Disabling [BETA API]
+	// public static function beginDisabled(disabled: Bool = true) {}
+	// public static function endDisabled() {}
+
+	// Clipping
+	public static function pushClipRect(clip_rect_min : ExtDynamic<ImVec2>, clip_rect_max : ExtDynamic<ImVec2>, intersect_with_current_clip_rect : Bool) {}
+	public static function popClipRect() {}
+
+	// Focus, Activation
+	public static function setItemDefaultFocus() {}
+	public static function setKeyboardFocusHere(offset : Int = 0) {}
+
+	// Item/Widgets Utilities
+	public static function isItemHovered(flags : ImGuiHoveredFlags = 0) : Bool {return false;}
+	public static function isItemActive() : Bool {return false;}
+	public static function isItemFocused() : Bool {return false;}
+	public static function isItemClicked(mouse_button : ImGuiMouseButton = 0) : Bool {return false;}
+	public static function isItemVisible() : Bool {return false;}
+	public static function isItemEdited() : Bool {return false;}
+	public static function isItemActivated() : Bool {return false;}
+	public static function isItemDeactivated() : Bool {return false;}
+	public static function isItemDeactivatedAfterEdit() : Bool {return false;}
+	public static function isItemToggledOpen() : Bool {return false;}
+	public static function isAnyItemHovered() : Bool {return false;}
+	public static function isAnyItemActive() : Bool {return false;}
+	public static function isAnyItemFocused() : Bool {return false;}
+	public static function getItemRectMin() : ExtDynamic<ImVec2> {return null;}
+	public static function getItemRectMax() : ExtDynamic<ImVec2> {return null;}
+	public static function getItemRectSize() : ExtDynamic<ImVec2> {return null;}
+	public static function setItemAllowOverlap() {}
+
+	// Viewports
+	// public static function getMainViewport(): IMViewport
+
+	// Miscellaneous Utilities
+	public static function isRectVisible(size : ExtDynamic<ImVec2>) : Bool {return false;}
+	public static function isRectVisible2(rect_min : ExtDynamic<ImVec2>, rect_max : ExtDynamic<ImVec2>) : Bool {return false;}
+	public static function getTime() : Float {return 0;}
+	public static function getFrameCount() : Int {return 0;}
+	public static function getForegroundDrawList() : ImDrawList {return null;}
+	//getForegroundDrawList(viewport) // Viewport API
+	public static function getBackgroundDrawList() : ImDrawList {return null;}
+	//getBackgroundDrawList(viewport) // Viewport API
+	//getDrawListSharedData()
+	static function get_style_color_name(idx : ImGuiCol) : hl.Bytes {return null;}
+	public static function getStyleColorName(idx : ImGuiCol) : String {
+		return @:privateAccess String.fromUTF8(get_style_color_name(idx));
+	}
+	public static function getStateStorage() : ImStateStorage {return null;}
+	//setStateStorage
+	public static function beginChildFrame(id : ImGuiID, size : ExtDynamic<ImVec2>, flags : ImGuiWindowFlags = 0) : Bool {return false;}
+	public static function endChildFrame() {}
+	@:deprecated("Obsolete: Use ImGuiListClipper")
+	public static function calcListClipping(items_count : Int, items_height : Single, out_items_display_start : hl.Ref<Int>, out_items_display_end : hl.Ref<Int>) {}
+
+	// Text Utilities
+	public static function calcTextSize(text : String, text_end : String = null, hide_text_after_double_hash : Bool = false, wrap_width : Single = -1.0) : ExtDynamic<ImVec2> {return null;}
+
+	// Color Utilities
+	public static function colorConvertU32ToFloat4(color : ImU32) : ExtDynamic<ImVec4> {return null;}
+	public static function colorConvertFloat4ToU32(color : ExtDynamic<ImVec4>) : ImU32 {return 0;}
+	public static function colorConvertRGBtoHSV(r : Single, g : Single, b : Single, out_h : hl.Ref<Single>, out_s : hl.Ref<Single>, out_v : hl.Ref<Single>) {}
+	public static function colorConvertHSVtoRGB(h : Single, s : Single, v : Single, out_r : hl.Ref<Single>, out_g : hl.Ref<Single>, out_b : hl.Ref<Single>) {}
+
+	// Inputs Utilities: Keyboard
+	public static function isKeyDown(user_key_index : Int) : Bool {return false;}
+	public static function isKeyPressed(user_key_index : Int, repeat : Bool = true) : Bool {return false;}
+	public static function isKeyReleased(user_key_index : Int) : Bool {return false;}
+	public static function getKeyPressedAmount(key_index : Int, repeat_delay : Single, rate : Single) : Int {return 0;}
+	//TODO: getKeyName
+	public static function captureKeyboardFromApp(want_capture_keyboard_value : Bool = true) {}
+	@:deprecated("Obsolete")
+	public static function getKeyIndex(imgui_key : ImGuiKey) : Int {return 0;}
+
+	// Inputs Utilities: Mouse
+	public static function isMouseDown(button : ImGuiMouseButton) : Bool {return false;}
+	public static function isMouseClicked(button : ImGuiMouseButton, repeat : Bool = false) : Bool {return false;}
+	public static function isMouseReleased(button : ImGuiMouseButton) : Bool {return false;}
+	public static function isMouseDoubleClicked(button : ImGuiMouseButton) : Bool {return false;}
+	//TODO: getMouseClickedCount
+	public static function isMouseHoveringRect(r_min : ExtDynamic<ImVec2>, r_max : ExtDynamic<ImVec2>, clip : Bool = true) : Bool {return false;}
+	public static function isMousePosValid(mouse_pos : ExtDynamic<ImVec2> = null) : Bool {return false;}
+	public static function isAnyMouseDown() : Bool {return false;}
+	public static function getMousePos() : ExtDynamic<ImVec2> {return null;}
+	public static function getMousePosOnOpeningCurrentPopup() : ExtDynamic<ImVec2> {return null;}
+	public static function isMouseDragging(button : ImGuiMouseButton, lock_threshold : Single = -1.0) : Bool {return false;}
+	public static function getMouseDragDelta(button : ImGuiMouseButton = 0, lock_threshold : Single = -1.0) : ExtDynamic<ImVec2> {return null;}
+	public static function resetMouseDragDelta(button : ImGuiMouseButton = 0) {}
+	public static function getMouseCursor() : ImGuiMouseCursor {return 0;}
+	public static function setMouseCursor(cursor_type : ImGuiMouseCursor) {}
+	public static function captureMouseFromApp(want_capture_mouse_value : Bool = true) {}
+
+	// Clipboard Utilities
+	static function get_clipboard_text() : hl.Bytes {return null;}
+	public static function getClipboardText() : String {
+		return @:privateAccess String.fromUTF8(get_clipboard_text());
+	}
+	public static function setClipboardText(text : String) {}
+
+	// Settings/.Ini Utilities
+	public static function loadIniSettingsFromDisk(ini_filename : String) {}
+	public static function loadIniSettingsFromMemory(ini_data : String, ini_size : Int = 0) {}
+	public static function saveIniSettingsToDisk(ini_filename : String) {}
+	static function save_ini_settings_to_memory(out_ini_size : hl.Ref<Int>) : hl.Bytes {return null;}
+	public static function saveIniSettingsToMemory(out_ini_size : hl.Ref<Int> = null) : String {
+		return @:privateAccess String.fromUTF8(save_ini_settings_to_memory(out_ini_size));
+	}
 
 	// Payload helpers
 	public static inline function setDragDropPayloadString(type: String, payload: String, cond: ImGuiCond = 0 ) : Bool {
@@ -1340,64 +1385,50 @@ class ImGui
 			return bytes.getI32(0);
 		return 0;
 	}
+	
+	// Debug Utilities
+	//debugCheckVersionAndDataLayout
+	
+	// Memory Allocators - Should not be exposed!
+	//setAllocatorFunctions(ImGuiMemAllocFunc alloc_func, ImGuiMemFreeFunc free_func, void* user_data = NULL);
+	//getAllocatorFunctions(ImGuiMemAllocFunc* p_alloc_func, ImGuiMemFreeFunc* p_free_func, void** p_user_data);
+	//memAlloc(size_t size);
+	//memFree(void* ptr);
+	
+	// (Optional) Platform/OS interface for multi-viewport support
+	// Read comments around the ImGuiPlatformIO structure for more details.
+	// Note: You may use GetWindowViewport() to get the current viewport of the current window.
+	// GetPlatformIO(): ImGuiPlatformIO
+	// UpdatePlatformWindows();                                        // call in main loop. will call CreateWindow/ResizeWindow/etc. platform functions for each secondary viewport, and DestroyWindow for each inactive viewport.
+	// RenderPlatformWindowsDefault(void* platform_render_arg = NULL, void* renderer_render_arg = NULL); // call in main loop. will call RenderWindow/SwapBuffers platform functions for each secondary viewport which doesn't have the ImGuiViewportFlags_Minimized flag set. May be reimplemented by user for custom rendering needs.
+	// DestroyPlatformWindows();                                       // call DestroyWindow platform functions for all viewports. call from backend Shutdown() if you need to close platform windows before imgui shutdown. otherwise will be called by DestroyContext().
+	// FindViewportByID(ImGuiID id): ImGuiViewport;                                   // this is a helper for backends.
+	// FindViewportByPlatformHandle(void* platform_handle): ImGuiViewport;            // this is a helper for backends. the type platform_handle is decided by the backend (e.g. HWND, MyWindow*, GLFWwindow* etc.)
 
+	// GetIO()->... wrappers
+	public static function setFontTexture(texture_id : ImTextureID) {} // Fonts->SetTexID
+	public static function setIniFilename(filename : String) {} // IniFilename
+	public static function addKeyChar(c : Int) {} // AddInputCharacter
+	public static function addKeyEvent(c : Int, down: Bool) {} // AddKeyEvent
+	// Shortcut to set MousePos, MouseWheel, MouseDown[0] and MouseDown[1]
+	public static function setEvents(dt : Single, mouse_x : Single, mouse_y : Single, wheel : Single, left_click : Bool, right_click : Bool) {}
+	public static function setDisplaySize(display_width:Int, display_height:Int) {} // DisplaySize
+	public static function wantCaptureMouse() : Bool {return false;} // WantCaptureMouse
+	public static function wantCaptureKeyboard() : Bool {return false;} // WantCaptureKeyboard
+	public static function setConfigFlags(flags:ImGuiConfigFlags = 0) : Void {} // ConfigFlags
+	public static function getConfigFlags() : ImGuiConfigFlags {return 0;} // ConfigFlags
+	public static function setUserData(data : Dynamic) {} // UserData; Should be safe to store anything and not be GCd.
+	public static function getUserData() : Dynamic {return null;} // UserData
+	
 
-    // Clipboard Utilities
-	static function get_clipboard_text() : hl.Bytes {return null;}
-    public static function getClipboardText() : String {
-		return @:privateAccess String.fromUTF8(get_clipboard_text());
-	}
-    public static function setClipboardText(text : String) {}
-
-    // Settings/.Ini Utilities
-    public static function loadIniSettingsFromDisk(ini_filename : String) {}
-    public static function loadIniSettingsFromMemory(ini_data : String, ini_size : Int = 0) {}
-    public static function saveIniSettingsToDisk(ini_filename : String) {}
-	static function save_ini_settings_to_memory(out_ini_size : hl.Ref<Int>) : hl.Bytes {return null;}
-    public static function saveIniSettingsToMemory(out_ini_size : hl.Ref<Int> = null) : String {
-		return @:privateAccess String.fromUTF8(save_ini_settings_to_memory(out_ini_size));
-	}
-
-	// IO
-	public static function setIniFilename(filename : String) {}
-
-	// Fonts
-
-	public static inline function addFontDefault(?config:ImFontConfig) : ImFont { return new ImFont(add_font_default(config)); }
-	static function add_font_default(config:ExtDynamic<ImFontConfig>) : ImFontPtr { return null; }
-	public static inline function addFontFromFileTtf( filename: String, size: Single, ?config: ImFontConfig = null, ?glyphRanges: hl.NativeArray<hl.UI16> = null ) : ImFont { return new ImFont(add_font_from_file_ttf(filename, size, config, glyphRanges)); }
-	public static function add_font_from_file_ttf( filename: String, size: Single, config: ExtDynamic<ImFontConfig>, glyphRanges: hl.NativeArray<hl.UI16>) : ImFontPtr { return null; }
-	public static inline function addFontFromMemoryTtf( bytes: hl.Bytes, size: Int, font_size: Single, ?config: ImFontConfig, ?glyphRanges: hl.NativeArray<hl.UI16>) : ImFont { return new ImFont(add_font_from_memory_ttf(bytes, size, font_size, config, glyphRanges)); }
-	public static function add_font_from_memory_ttf( bytes: hl.Bytes, size: Int, font_size: Single, config: ExtDynamic<ImFontConfig>, glyphRanges: hl.NativeArray<hl.UI16>) : ImFontPtr { return null; }
+	// ImFontAtlas / ImGui::GetIO().Fonts->... wrappers
+	public static function addFontDefault(?config:ExtDynamic<ImFontConfig>) : ImFont { return null; }
+	public static function addFontFromFileTtf( filename: String, size: Single, config: ExtDynamic<ImFontConfig> = null, glyphRanges: hl.NativeArray<hl.UI16> = null) : ImFont { return null; }
+	public static function addFontFromMemoryTtf( bytes: hl.Bytes, size: Int, font_size: Single, config: ExtDynamic<ImFontConfig> = null, glyphRanges: hl.NativeArray<hl.UI16> = null) : ImFont { return null; }
 	public static function buildFont() {} // flat version of ImGui::GetIO().Fonts->Build();
-	public static function getTexDataAsRgba32() : Dynamic {return null;} // : {buffer:hl.Bytes, width:Int, height:Int} { return{ buffer: null, width: 0, height: 0 }; }
 
 	// internal functions
 	public static function initialize(render_fn:Dynamic->Void) : Dynamic {return null;}
-	public static function setFontTexture(texture_id : ImTextureID) {}
-	public static function addKeyChar(c : Int) {}
-	public static function addKeyEvent(c : Int, down: Bool) {}
-	public static function setEvents(dt : Single, mouse_x : Single, mouse_y : Single, wheel : Single, left_click : Bool, right_click : Bool) {}
-	public static function setDisplaySize(display_width:Int, display_height:Int) {}
-	public static function wantCaptureMouse() : Bool {return false;}
-	public static function wantCaptureKeyboard() : Bool {return false;}
-	public static function setConfigFlags(flags:ImGuiConfigFlags = 0) : Void {}
-	public static function getConfigFlags() : ImGuiConfigFlags {return 0;}
-	public static function setUserData(data : Dynamic) {}
-	public static function getUserData() : Dynamic {return null;}
-
-	// Draw Lists
-	public static inline function getWindowDrawList() : ImDrawList { return new ImDrawList( drawlist_get_window_draw_list() ); }
-	public static inline function getForegroundDrawList() : ImDrawList { return new ImDrawList( drawlist_get_foreground_draw_list() ); }
-	public static inline function getBackgroundDrawList() : ImDrawList { return new ImDrawList( drawlist_get_background_draw_list() ); }
-
-	static function drawlist_get_window_draw_list() : ImDrawListPtr { return null; }
-	static function drawlist_get_foreground_draw_list() : ImDrawListPtr { return null; }
-	static function drawlist_get_background_draw_list() : ImDrawListPtr { return null; }
-
-	// State storage
-	public static inline function getStateStorage() : ImStateStorage { return new ImStateStorage( get_state_storage() ); }
-
-	static function get_state_storage() : ImStateStoragePtr { return null; }
+	public static function getTexDataAsRgba32() : Dynamic {return null;} // : {buffer:hl.Bytes, width:Int, height:Int} { return{ buffer: null, width: 0, height: 0 }; }
 
 }

--- a/imgui/ImGui.hx
+++ b/imgui/ImGui.hx
@@ -825,43 +825,45 @@ class ImGui
 
 	// styles
 	public static function styleColorsDark(style : ExtDynamic<ImGuiStyle> = null) {}
-    public static function styleColorsClassic(style : ExtDynamic<ImGuiStyle> = null) {}
-    public static function styleColorsLight(style : ExtDynamic<ImGuiStyle> = null) {}
+	public static function styleColorsClassic(style : ExtDynamic<ImGuiStyle> = null) {}
+	public static function styleColorsLight(style : ExtDynamic<ImGuiStyle> = null) {}
 
 	// windows
-    public static function begin(name : String, open : hl.Ref<Bool> = null, flags : ImGuiWindowFlags = 0) : Bool {return false;}
+	public static function begin(name : String, open : hl.Ref<Bool> = null, flags : ImGuiWindowFlags = 0) : Bool {return false;}
 	public static function end() {}
 
 	// Child windows
-    public static function beginChild(str_id : String, size : ExtDynamic<ImVec2> = null, border : Bool = false, flags : ImGuiWindowFlags = 0) : Bool {return false;}
-    public static function beginChild2(id : Int, size : ExtDynamic<ImVec2> = null, border : Bool = false, flags : ImGuiWindowFlags = 0) : Bool {return false;}
+	public static function beginChild(str_id : String, size : ExtDynamic<ImVec2> = null, border : Bool = false, flags : ImGuiWindowFlags = 0) : Bool {return false;}
+	public static function beginChild2(id : Int, size : ExtDynamic<ImVec2> = null, border : Bool = false, flags : ImGuiWindowFlags = 0) : Bool {return false;}
 	public static function endChild() {}
 
 	// Windows utilities
 	public static function isWindowAppearing() : Bool {return false;}
-    public static function isWindowCollapsed() : Bool {return false;}
-    public static function isWindowFocused(flags : ImGuiFocusedFlags = 0) {return false;}
-    public static function isWindowHovered(flags : ImGuiFocusedFlags = 0) {return false;}
-    public static function getWindowPos() : ExtDynamic<ImVec2> {return null;}
-    public static function getWindowSize() : ExtDynamic<ImVec2> {return null;}
-    public static function getWindowWidth() : Single {return 0;}
+	public static function isWindowCollapsed() : Bool {return false;}
+	public static function isWindowFocused(flags : ImGuiFocusedFlags = 0) {return false;}
+	public static function isWindowHovered(flags : ImGuiFocusedFlags = 0) {return false;}
+	public static function getWindowDpiScale(): Single { return 0; }
+	public static function getWindowPos() : ExtDynamic<ImVec2> {return null;}
+	public static function getWindowSize() : ExtDynamic<ImVec2> {return null;}
+	public static function getWindowWidth() : Single {return 0;}
 	public static function getWindowHeight(): Single {return 0;}
 
-    public static function setNextWindowPos(pos : ExtDynamic<ImVec2>, cond : ImGuiCond = 0, pivot : ExtDynamic<ImVec2> = null) {}
-    public static function setNextWindowSize(size: ExtDynamic<ImVec2>, cond : ImGuiCond = 0) {}
-    public static function setNextWindowSizeConstraints(size_min : ExtDynamic<ImVec2>, size_max : ExtDynamic<ImVec2>) {}
-    public static function setNextWindowContentSize(size : ExtDynamic<ImVec2>) {}
-    public static function setNextWindowCollapsed(collapsed : Bool, cond : ImGuiCond = 0) {}
-    public static function setNextWindowFocus() {}
-    public static function setNextWindowBgAlpha(alpha : Single) {}
-    public static function setWindowPos(pos : ExtDynamic<ImVec2>, cond : ImGuiCond = 0) {}
-    public static function setWindowSize(size : ExtDynamic<ImVec2>, cond : ImGuiCond = 0) {}
-    public static function setWindowCollapsed(collapsed : Bool, cond : ImGuiCond = 0) {}
-    public static function setWindowFocus() {}
-    public static function setWindowFontScale(scale : Single) {}
-    public static function setWindowPos2(name : String, pos : ExtDynamic<ImVec2>, cond : ImGuiCond = 0) {}
-    public static function setWindowSize2(name : String, size : ExtDynamic<ImVec2>, cond : ImGuiCond = 0) {}
-    public static function setWindowCollapsed2(name : String, collapsed : Bool, cond : ImGuiCond = 0) {}
+	// Window manipulation
+	public static function setNextWindowPos(pos : ExtDynamic<ImVec2>, cond : ImGuiCond = 0, pivot : ExtDynamic<ImVec2> = null) {}
+	public static function setNextWindowSize(size: ExtDynamic<ImVec2>, cond : ImGuiCond = 0) {}
+	public static function setNextWindowSizeConstraints(size_min : ExtDynamic<ImVec2>, size_max : ExtDynamic<ImVec2>) {}
+	public static function setNextWindowContentSize(size : ExtDynamic<ImVec2>) {}
+	public static function setNextWindowCollapsed(collapsed : Bool, cond : ImGuiCond = 0) {}
+	public static function setNextWindowFocus() {}
+	public static function setNextWindowBgAlpha(alpha : Single) {}
+	public static function setWindowPos(pos : ExtDynamic<ImVec2>, cond : ImGuiCond = 0) {}
+	public static function setWindowSize(size : ExtDynamic<ImVec2>, cond : ImGuiCond = 0) {}
+	public static function setWindowCollapsed(collapsed : Bool, cond : ImGuiCond = 0) {}
+	public static function setWindowFocus() {}
+	public static function setWindowFontScale(scale : Single) {}
+	public static function setWindowPos2(name : String, pos : ExtDynamic<ImVec2>, cond : ImGuiCond = 0) {}
+	public static function setWindowSize2(name : String, size : ExtDynamic<ImVec2>, cond : ImGuiCond = 0) {}
+	public static function setWindowCollapsed2(name : String, collapsed : Bool, cond : ImGuiCond = 0) {}
 	public static function setWindowFocus2(name : String) {}
 
 	// Docking
@@ -886,79 +888,93 @@ class ImGui
 
 	// Content region
 	public static function getContentRegionMax() : ExtDynamic<ImVec2> {return null;}
-    public static function getContentRegionAvail() : ExtDynamic<ImVec2> {return null;}
-    public static function getWindowContentRegionMin() : ExtDynamic<ImVec2> {return null;}
-    public static function getWindowContentRegionMax() : ExtDynamic<ImVec2> {return null;}
+	public static function getContentRegionAvail() : ExtDynamic<ImVec2> {return null;}
+	public static function getWindowContentRegionMin() : ExtDynamic<ImVec2> {return null;}
+	public static function getWindowContentRegionMax() : ExtDynamic<ImVec2> {return null;}
+	@:deprecated // Obsoleted in latest imgui
 	public static function getWindowContentRegionWidth() : Single {return 0;}
 
 	// Windows Scrolling
 	public static function getScrollX() : Single {return 0;}
-    public static function getScrollY() : Single {return 0;}
-    public static function getScrollMaxX() : Single {return 0;}
-    public static function getScrollMaxY() : Single {return 0;}
-    public static function setScrollX(scroll_x : Single) {}
-    public static function setScrollY(scroll_y : Single) {}
-    public static function setScrollHereX(center_x_ratio : Single = 0.5) {}
-    public static function setScrollHereY(center_y_ratio : Single = 0.5) {}
-    public static function setScrollFromPosX(local_x : Single, center_x_ratio : Single = 0.5) {}
+	public static function getScrollY() : Single {return 0;}
+	public static function setScrollX(scroll_x : Single) {}
+	public static function setScrollY(scroll_y : Single) {}
+	public static function getScrollMaxX() : Single {return 0;}
+	public static function getScrollMaxY() : Single {return 0;}
+	public static function setScrollHereX(center_x_ratio : Single = 0.5) {}
+	public static function setScrollHereY(center_y_ratio : Single = 0.5) {}
+	public static function setScrollFromPosX(local_x : Single, center_x_ratio : Single = 0.5) {}
 	public static function setScrollFromPosY(local_y : Single, center_y_ratio : Single = 0.5) {}
 
-	// Parameters stacks
-    public static function pushStyleColor(idx : ImGuiCol, col : ImU32) {}
-    public static function pushStyleColor2(idx : ImGuiCol, col : ExtDynamic<ImVec4>) {}
-    public static function popStyleColor(count : Int = 1) {}
-    public static function pushStyleVar(idx : ImGuiStyleVar, val : Single) {}
-    public static function pushStyleVar2(idx : ImGuiStyleVar, val : ExtDynamic<ImVec2>) {}
-    public static function popStyleVar(count : Int = 1) {}
-    public static function getStyleColorVec4(idx : ImGuiCol) : ExtDynamic<ImVec4> {return null;}
-    public static function getFontSize() : Single {return 0;}
-    public static function getFontTexUvWhitePixel() : ExtDynamic<ImVec2> {return null;}
-    public static function getColorU32(idx : ImGuiCol, alpha_mul : Single = 1.0) : ImU32 {return 0;}
-    public static function getColorU322(col : ExtDynamic<ImVec4>) : ImU32 {return 0;}
-    public static function getColorU323(col : ImU32) : ImU32 {return 0;}
-    public static function pushItemWidth(item_width : Single) {}
-    public static function popItemWidth() {}
-    public static function setNextItemWidth(item_width : Single) {}
-    public static function calcItemWidth() : Single {return 0;}
-    public static function pushTextWrapPos(wrap_local_pos_x : Single = 0.0) {}
-    public static function popTextWrapPos() {}
-    public static function pushAllowKeyboardFocus(allow_keyboard_focus : Bool) {}
-    public static function popAllowKeyboardFocus() {}
-    public static function pushButtonRepeat(repeat : Bool) {}
-    public static function popButtonRepeat() {}
+	// Parameters stacks (shared)
+	public static function pushFont( font: ImFont ) {}
+	public static function popFont() {}
+	public static function pushStyleColor(idx : ImGuiCol, col : ImU32) {}
+	public static function pushStyleColor2(idx : ImGuiCol, col : ExtDynamic<ImVec4>) {}
+	public static function popStyleColor(count : Int = 1) {}
+	public static function pushStyleVar(idx : ImGuiStyleVar, val : Single) {}
+	public static function pushStyleVar2(idx : ImGuiStyleVar, val : ExtDynamic<ImVec2>) {}
+	public static function popStyleVar(count : Int = 1) {}
+	public static function pushAllowKeyboardFocus(allow_keyboard_focus : Bool) {}
+	public static function popAllowKeyboardFocus() {}
+	public static function pushButtonRepeat(repeat : Bool) {}
+	public static function popButtonRepeat() {}
+	
+	// Parameters stacks (current window)
+	public static function pushItemWidth(item_width : Single) {}
+	public static function popItemWidth() {}
+	public static function setNextItemWidth(item_width : Single) {}
+	public static function calcItemWidth() : Single {return 0;}
+	public static function pushTextWrapPos(wrap_local_pos_x : Single = 0.0) {}
+	public static function popTextWrapPos() {}
+	
+	// Style read access
+	public static function getFont(): ImFont {return null;}
+	public static function getFontSize() : Single {return 0;}
+	public static function getFontTexUvWhitePixel() : ExtDynamic<ImVec2> {return null;}
+	public static function getColorU32(idx : ImGuiCol, alpha_mul : Single = 1.0) : ImU32 {return 0;}
+	public static function getColorU322(col : ExtDynamic<ImVec4>) : ImU32 {return 0;}
+	public static function getColorU323(col : ImU32) : ImU32 {return 0;}
+	public static function getStyleColorVec4(idx : ImGuiCol) : ExtDynamic<ImVec4> {return null;}
 
 	// Cursor / Layout
-    public static function separator() {}
-    public static function sameLine(offset_from_start_x : Single = 0.0, spacing : Single = -1.0) {}
-    public static function newLine() {}
-    public static function spacing() {}
-    public static function dummy(size : ExtDynamic<ImVec2>) {}
-    public static function indent(indent_w : Single = 0.0) {}
-    public static function unindent(indent_w : Single = 0.0) {}
-    public static function beginGroup() {}
-    public static function endGroup() {}
-    public static function getCursorPos() : ExtDynamic<ImVec2> {return null;}
-    public static function getCursorPosX() : Single {return 0;}
-    public static function getCursorPosY() : Single {return 0;}
-    public static function setCursorPos(local_pos : ExtDynamic<ImVec2>) {}
-    public static function setCursorPosX(local_x : Single) {}
-    public static function setCursorPosY(local_y : Single) {}
-    public static function getCursorStartPos() : ExtDynamic<ImVec2> {return null;}
-    public static function getCursorScreenPos() : ExtDynamic<ImVec2> {return null;}
-    public static function setCursorScreenPos(pos : ExtDynamic<ImVec2>) {}
-    public static function alignTextToFramePadding() {}
-    public static function getTextLineHeight() : Single {return 0;}
-    public static function getTextLineHeightWithSpacing() : Single {return 0;}
-    public static function getFrameHeight() : Single {return 0;}
+	public static function separator() {}
+	public static function sameLine(offset_from_start_x : Single = 0.0, spacing : Single = -1.0) {}
+	public static function newLine() {}
+	public static function spacing() {}
+	public static function dummy(size : ExtDynamic<ImVec2>) {}
+	public static function indent(indent_w : Single = 0.0) {}
+	public static function unindent(indent_w : Single = 0.0) {}
+	public static function beginGroup() {}
+	public static function endGroup() {}
+	public static function getCursorPos() : ExtDynamic<ImVec2> {return null;}
+	public static function getCursorPosX() : Single {return 0;}
+	public static function getCursorPosY() : Single {return 0;}
+	public static function setCursorPos(local_pos : ExtDynamic<ImVec2>) {}
+	public static function setCursorPosX(local_x : Single) {}
+	public static function setCursorPosY(local_y : Single) {}
+	public static function getCursorStartPos() : ExtDynamic<ImVec2> {return null;}
+	public static function getCursorScreenPos() : ExtDynamic<ImVec2> {return null;}
+	public static function setCursorScreenPos(pos : ExtDynamic<ImVec2>) {}
+	public static function alignTextToFramePadding() {}
+	public static function getTextLineHeight() : Single {return 0;}
+	public static function getTextLineHeightWithSpacing() : Single {return 0;}
+	public static function getFrameHeight() : Single {return 0;}
 	public static function getFrameHeightWithSpacing() : Single {return 0;}
 
 	// ID stack/scopes
 	public static function pushID(str_id : String) {}
-    public static function pushID2(str_id_begin : String, str_id_end : String) {}
-    public static function pushID3(int_id : Int) {}
-    public static function popID() {}
-    public static function getID(str_id : String) : Int {return 0;}
-    public static function getID2(str_id_begin : String, str_id_end : String) : Int {return 0;}
+	@:native("push_id_sub") public static function pushIDSub(str_id : String, begin : Int, end : Int) {}
+	@:native("push_id_int") public static function pushIDInt(int_id : Int) {}
+	@:native("push_id_ptr") public static function pushIDPtr(obj: Any) {}
+	public static function popID() {}
+	public static function getID(str_id : String) : Int {return 0;}
+	@:native("get_id_sub") public static function getIDSub(str_id : String, begin: Int, end: Int) : Int {return 0;}
+	@:native("get_id_ptr") public static function getIDPtr(obj: Any) : Int {return 0;}
+	
+	@:deprecated("use getIDSub") public static function getID2(str_id : String, begin: Int, end: Int) : Int {return getIDSub(str_id, begin, end);}
+	@:deprecated("use pushIDSub") public static inline function pushID2(str_id : String, begin : Int, end : Int) { pushIDSub(str_id, begin, end); }
+	@:deprecated("use pushIDInt") public static inline function pushID3(int_id : Int) { pushIDInt(int_id); }
 
     // Widgets: Text
     public static function text(text : String) {}
@@ -1324,9 +1340,6 @@ class ImGui
 	public static function add_font_from_file_ttf( filename: String, size: Single, config: ExtDynamic<ImFontConfig>, glyphRanges: hl.NativeArray<hl.UI16>) : ImFontPtr { return null; }
 	public static inline function addFontFromMemoryTtf( bytes: hl.Bytes, size: Int, font_size: Single, ?config: ImFontConfig, ?glyphRanges: hl.NativeArray<hl.UI16>) : ImFont { return new ImFont(add_font_from_memory_ttf(bytes, size, font_size, config, glyphRanges)); }
 	public static function add_font_from_memory_ttf( bytes: hl.Bytes, size: Int, font_size: Single, config: ExtDynamic<ImFontConfig>, glyphRanges: hl.NativeArray<hl.UI16>) : ImFontPtr { return null; }
-	public static inline function pushFont( font: ImFont ) { push_font( @:privateAccess font.ptr );	}
-	static function push_font( font: ImFontPtr ) {}
-	public static function popFont() {}
 	public static function buildFont() {} // flat version of ImGui::GetIO().Fonts->Build();
 	public static function getTexDataAsRgba32() : Dynamic {return null;} // : {buffer:hl.Bytes, width:Int, height:Int} { return{ buffer: null, width: 0, height: 0 }; }
 

--- a/imgui/ImGui.hx
+++ b/imgui/ImGui.hx
@@ -1145,37 +1145,50 @@ class ImGui
     public static function plotLines(label : String, values : hl.NativeArray<Single>, values_offset : Int = 0, overlay_text : String = null, scale_min : Single = FLT_MAX, scale_max : Single = FLT_MAX, graph_size : ExtDynamic<ImVec2>) {}
 	public static function plotHistogram(label : String, values : hl.NativeArray<Single>, values_offset : Int = 0, overlay_text : String = null, scale_min : Single = FLT_MAX, scale_max : Single = FLT_MAX, graph_size : ExtDynamic<ImVec2>) {}
 
-    // Widgets: Value() Helpers.
-    public static function valueBool(prefix : String, b : Bool) {}
-    public static function valueInt(prefix : String, v : Int) {}
+	// Widgets: Value() Helpers.
+	public static function valueBool(prefix : String, b : Bool) {}
+	public static function valueInt(prefix : String, v : Int) {}
 	public static function valueSingle(prefix : String, v : Single, float_format : String = null) {}
+	public static function valueDouble(prefix: String, v: Float, double_format: String = null) {}
 
-    // Widgets: Menus
-    public static function beginMenuBar() : Bool {return false;}
-    public static function endMenuBar() {}
-    public static function beginMainMenuBar() : Bool {return false;}
-    public static function endMainMenuBar() {}
-    public static function beginMenu(label : String, enabled : Bool = true) : Bool {return false;}
-    public static function endMenu() {}
-    public static function menuItem(label : String, shortcut : String = null, selected : Bool = false, enabled : Bool = true) : Bool {return false;}
-    public static function menuItem2(label : String, shortcut : String, p_selected : hl.Ref<Bool>, enabled : Bool = true) : Bool {return false;}
+	// Widgets: Menus
+	public static function beginMenuBar() : Bool {return false;}
+	/** Only call EndMenuBar() if BeginMenuBar() returns true! **/
+	public static function endMenuBar() {}
+	public static function beginMainMenuBar() : Bool {return false;}
+	/** Only call EndMainMenuBar() if BeginMainMenuBar() returns true! **/
+	public static function endMainMenuBar() {}
+	public static function beginMenu(label : String, enabled : Bool = true) : Bool {return false;}
+	/** Only call EndMenu() if BeginMenu() returns true! **/
+	public static function endMenu() {}
+	public static function menuItem(label : String, shortcut : String = null, selected : Bool = false, enabled : Bool = true) : Bool {return false;}
+	public static function menuItem2(label : String, shortcut : String, p_selected : hl.Ref<Bool>, enabled : Bool = true) : Bool {return false;}
 
 	// ToolTips
-    public static function beginTooltip() {}
-    public static function endTooltip() {}
-	public static function setTooltip(fmt : String) {}
+	public static function beginTooltip() {}
+	public static function endTooltip() {}
+	public static function setTooltip(fmt : String) {} // TODO: Allow format args
 
-	// Popups
+	// Popups, Modals
+	
+	// Popups: begin/end function
+	public static function beginPopup(str_id : String, flags : ImGuiWindowFlags = 0) : Bool {return false;}
+	public static function beginPopupModal(name : String, p_open : hl.Ref<Bool> = null, flags : ImGuiWindowFlags = 0) : Bool {return false;}
+	public static function endPopup() {}
+	
+	// Popups: open/close functions
 	public static function openPopup(str_id : String) {}
-    public static function beginPopup(str_id : String, flags : ImGuiWindowFlags = 0) : Bool {return false;}
-    public static function beginPopupContextItem(str_id : String = null, mouse_button : ImGuiMouseButton = 1) : Bool {return false;}
-    public static function beginPopupContextWindow(str_id : String = null, mouse_button : ImGuiMouseButton = 1, also_over_items : Bool = true) : Bool {return false;}
-    public static function beginPopupContextVoid(str_id : String = null, mouse_button : ImGuiMouseButton= 1) : Bool {return false;}
-    public static function beginPopupModal(name : String, p_open : hl.Ref<Bool> = null, flags : ImGuiWindowFlags = 0) : Bool {return false;}
-    public static function endPopup() {}
-    public static function openPopupOnItemClick(str_id : String = null, mouse_button : ImGuiMouseButton = 1) : Void {}
-    public static function isPopupOpen(str_id : String) : Bool {return false;}
+	// TODO: openPopup with id: ImGuiID
+	public static function openPopupOnItemClick(str_id : String = null, mouse_button : ImGuiMouseButton = 1) : Void {}
 	public static function closeCurrentPopup() {}
+	
+	// Popups: open+begin combined function helpers
+	public static function beginPopupContextItem(str_id : String = null, mouse_button : ImGuiMouseButton = 1) : Bool {return false;}
+	public static function beginPopupContextWindow(str_id : String = null, mouse_button : ImGuiMouseButton = 1, also_over_items : Bool = true) : Bool {return false;}
+	public static function beginPopupContextVoid(str_id : String = null, mouse_button : ImGuiMouseButton= 1) : Bool {return false;}
+	
+	// Popups: query functions
+	public static function isPopupOpen(str_id : String) : Bool {return false;}
 
     // Columns
     public static function columns(count : Int = 1, id : String = null, border : Bool = true) {}
@@ -1212,6 +1225,7 @@ class ImGui
 	public static function endTabBar() {}
 	public static function beginTabItem(label : String, p_open : hl.Ref<Bool> = null, flags : ImGuiTabItemFlags = 0) : Bool {return false;}
 	public static function endTabItem() {}
+	public static function tabItemButton(label : String, flags : ImGuiTabItemFlags = 0) : Bool {return false;}
 	public static function setTabItemClosed(tab_or_docked_window_label : String) {}
 
 	// Logging/Capture
@@ -1220,7 +1234,7 @@ class ImGui
 	public static function logToClipboard(auto_open_depth : Int = -1) {}
 	public static function logFinish() {}
 	public static function logButtons() {}
-	public static function logText(text : String) {}
+	public static function logText(text : String) {} // TODO: Allow format args
 
     // Clipping
     public static function pushClipRect(clip_rect_min : ExtDynamic<ImVec2>, clip_rect_max : ExtDynamic<ImVec2>, intersect_with_current_clip_rect : Bool) {}

--- a/imgui/ImGui.hx
+++ b/imgui/ImGui.hx
@@ -797,9 +797,9 @@ class ImGui
 	public static inline var FLT_MAX = 3.402823466e+38;
 
 	// Context
-    public static function createContext() : ImContextPtr {return null;}
-    public static function destroyContext(ctx : ImContextPtr = null) {}
-    public static function getCurrentContext() : ImContextPtr {return null;}
+	public static function createContext() : ImContextPtr {return null;}
+	public static function destroyContext(ctx : ImContextPtr = null) {}
+	public static function getCurrentContext() : ImContextPtr {return null;}
 	public static function setCurrentContext(ctx : ImContextPtr) {}
 
 	// Main
@@ -810,15 +810,16 @@ class ImGui
 	public static function render() {}
 
 	// Demo, Debug, Information
-    public static function showDemoWindow(open : hl.Ref<Bool> = null) {}
-    public static function showAboutWindow(open : hl.Ref<Bool> = null) {}
+	public static function showDemoWindow(open : hl.Ref<Bool> = null) {}
 	public static function showMetricsWindow(open : hl.Ref<Bool> = null) {}
+	public static function showStackToolWindow(open : hl.Ref<Bool> = null) {}
+	public static function showAboutWindow(open : hl.Ref<Bool> = null) {}
 	public static function showStyleEditor(style : ExtDynamic<ImGuiStyle> = null) {}
-    public static function showStyleSelector(label : String) : Bool {return false;}
-    public static function showFontSelector(label : String) {}
+	public static function showStyleSelector(label : String) : Bool {return false;}
+	public static function showFontSelector(label : String) {}
 	public static function showUserGuide() {}
 	static function get_version() : hl.Bytes {return null;}
-    public static function getVersion() : String {
+	public static inline function getVersion() : String {
 		return @:privateAccess String.fromUTF8(get_version());
 	}
 

--- a/imgui/ImGui.hx
+++ b/imgui/ImGui.hx
@@ -672,6 +672,7 @@ class ImFontConfig
 private typedef ImFontPtr = hl.Abstract<"imfont">;
 private typedef ImDrawListPtr = hl.Abstract<"imdrawlist">;
 private typedef ImStateStoragePtr = hl.Abstract<"imstatestorage">;
+private typedef ImContextPtr = hl.Abstract<"imcontext">;
 private typedef ImGuiDockNode = hl.Abstract<"imguidocknode">;
 
 @:hlNative("hlimgui")
@@ -796,10 +797,10 @@ class ImGui
 	public static inline var FLT_MAX = 3.402823466e+38;
 
 	// Context
-    public static function createContext() : hl.Bytes {return null;}
-    public static function destroyContext(ctx : hl.Bytes = null) {}
-    public static function getCurrentContext() : hl.Bytes {return null;}
-	public static function setCurrentContext(ctx : hl.Bytes) {}
+    public static function createContext() : ImContextPtr {return null;}
+    public static function destroyContext(ctx : ImContextPtr = null) {}
+    public static function getCurrentContext() : ImContextPtr {return null;}
+	public static function setCurrentContext(ctx : ImContextPtr) {}
 
 	// Main
 	public static function getStyle() : ExtDynamic<ImGuiStyle> {return null;}

--- a/imgui/ImGui.hx
+++ b/imgui/ImGui.hx
@@ -976,13 +976,15 @@ class ImGui
 	@:deprecated("use pushIDSub") public static inline function pushID2(str_id : String, begin : Int, end : Int) { pushIDSub(str_id, begin, end); }
 	@:deprecated("use pushIDInt") public static inline function pushID3(int_id : Int) { pushIDInt(int_id); }
 
-    // Widgets: Text
-    public static function text(text : String) {}
-    public static function textColored(col : ExtDynamic<ImVec4>, fmt : String) {}
-    public static function textDisabled(text : String) {}
-    public static function textWrapped(text : String) {}
-    public static function labelText(label : String, text : String) {}
-    public static function bulletText(text : String) {}
+	// Widgets: Text
+	// TODO: TextUnformatted(text: String, ?start: Int, ?end: Int)
+	// TODO: Allow format arguments to be passed
+	public static function text(text : String) {}
+	public static function textColored(col : ExtDynamic<ImVec4>, fmt : String) {}
+	public static function textDisabled(text : String) {}
+	public static function textWrapped(text : String) {}
+	public static function labelText(label : String, text : String) {}
+	public static function bulletText(text : String) {}
 
 	// Widgets: Main
 	public static function button(name : String, ?size : ExtDynamic<ImVec2>) : Bool {return false;}
@@ -1007,11 +1009,12 @@ class ImGui
 	public static function progressBar(fraction : Single, size_arg : ExtDynamic<ImVec2> = null, overlay : String = null) {}
 	public static function bullet() {}
 
-    // Widgets: Combo Box
-    public static function beginCombo(label : String, preview_value : String, flags : ImGuiComboFlags = 0) : Bool {return false;}
-    public static function endCombo() {}
-    public static function combo(label : String, current_item : hl.Ref<Int>, items : hl.NativeArray<String>, popup_max_height_in_items : Int = -1) : Bool {return false;}
+	// Widgets: Combo Box
+	public static function beginCombo(label : String, preview_value : String, flags : ImGuiComboFlags = 0) : Bool {return false;}
+	public static function endCombo() {}
+	public static function combo(label : String, current_item : hl.Ref<Int>, items : hl.NativeArray<String>, popup_max_height_in_items : Int = -1) : Bool {return false;}
 	public static function combo2(label : String, current_item : hl.Ref<Int>, items_separated_by_zeros : String, popup_max_height_in_items : Int = -1) : Bool {return false;}
+	// TODO: comboCallback variant
 
 	// Widgets: Drags
 	public static function dragFloat(label : String, v : hl.Ref<Single>, v_speed : Single = 1.0, v_min : Single = 0.0, v_max : Single = 0.0, format : String = "%.3f", flags : ImGuiSliderFlags = 0) : Bool {return false;}
@@ -1120,10 +1123,22 @@ class ImGui
     public static function selectable(label : String, selected : Bool = false, flags : ImGuiSelectableFlags = 0, size : ExtDynamic<ImVec2> = null) : Bool {return false;}
 	public static function selectable2(label : String, p_selected : hl.Ref<Bool>, flags : ImGuiSelectableFlags = 0, size : ExtDynamic<ImVec2> = null) : Bool {return false;}
 
-    // Widgets: List Boxes
-    public static function listBox(label : String, current_item : hl.Ref<Int>, items : hl.NativeArray<String>, height_in_items : Int = -1) : Bool {return false;}
-    public static function listBoxHeader(label : String, size : ExtDynamic<ImVec2> = null) : Bool {return false;}
-    public static function listBoxHeader2(label : String, items_count : Int, height_in_items : Int = -1) : Bool {return false;}
+	// Widgets: List Boxes
+	/**
+		- Choose frame width:   size.x > 0.0f: custom  /  size.x < 0.0f or -FLT_MIN: right-align   /  size.x = 0.0f (default): use current ItemWidth
+		- Choose frame height:  size.y > 0.0f: custom  /  size.y < 0.0f or -FLT_MIN: bottom-align  /  size.y = 0.0f (default): arbitrary default height which can fit ~7 items
+	**/
+	public static function beginListBox(label: String, size: ExtDynamic<ImVec2> = null): Bool { return false; }
+	/** Only call if beginListBox returns true! **/
+	public static function endListBox(): Bool { return false; }
+	
+	public static function listBox(label : String, current_item : hl.Ref<Int>, items : hl.NativeArray<String>, height_in_items : Int = -1) : Bool {return false;}
+	// TODO: Callback variant
+	@:deprecated("Use beginListBox")
+	public static function listBoxHeader(label : String, size : ExtDynamic<ImVec2> = null) : Bool {return beginListBox(label, size);}
+	@:deprecated("Obsolete")
+	public static function listBoxHeader2(label : String, items_count : Int, height_in_items : Int = -1) : Bool {return false;}
+	@:deprecated("Use endListBox")
 	public static function listBoxFooter() {}
 
 	// Widgets: Data Plotting

--- a/imgui/ImGui.hx
+++ b/imgui/ImGui.hx
@@ -675,35 +675,33 @@ private typedef ImStateStoragePtr = hl.Abstract<"imstatestorage">;
 private typedef ImGuiDockNode = hl.Abstract<"imguidocknode">;
 
 @:hlNative("hlimgui")
-class ImDrawList
+abstract ImDrawList(ImDrawListPtr) from ImDrawListPtr to ImDrawListPtr
 {
-	var ptr: ImDrawListPtr;
+	public function new(ptr: ImDrawListPtr) { this = ptr; }
 
-	public function new(ptr: ImDrawListPtr) { this.ptr = ptr; }
-
-	public function addLine( p1: ImVec2, p2: ImVec2, col: ImU32, thickness: Single = 1.0 ) { drawlist_add_line( ptr, p1, p2, col, thickness ); }
-	public function addRect( pMin: ImVec2, pMax: ImVec2, col: ImU32, rounding: Single = 0.0, roundingCorners: ImDrawFlags = ImDrawFlags.None, thickness: Single = 1.0 ) { drawlist_add_rect( ptr, pMin, pMax, col, rounding, roundingCorners, thickness ); }
-	public function addRectFilled( pMin: ImVec2, pMax: ImVec2, col: ImU32, rounding: Single = 0.0, roundingCorners: ImDrawFlags = ImDrawFlags.None ) { drawlist_add_rect_filled( ptr, pMin, pMax, col, rounding, roundingCorners); }
-	public function addRectFilledMultiColor( pMin: ExtDynamic<ImVec2>, pMax: ExtDynamic<ImVec2>, col_upr_left: ImU32, col_upr_right: ImU32, col_bot_right: ImU32, col_bot_left: ImU32 ) { drawlist_add_rect_filled_multicolor( ptr, pMin, pMax, col_upr_left, col_upr_right, col_bot_right, col_bot_left ); }
-	public function addQuad( p1: ExtDynamic<ImVec2>, p2: ExtDynamic<ImVec2>, p3: ExtDynamic<ImVec2>, p4: ExtDynamic<ImVec2>, col: ImU32, thickness: Single = 1.0 ) { drawlist_add_quad(ptr, p1, p2, p3, p4, col, thickness ); }
-	public function addQuadFilled( p1: ExtDynamic<ImVec2>, p2: ExtDynamic<ImVec2>, p3: ExtDynamic<ImVec2>, p4: ExtDynamic<ImVec2>, col: ImU32 ) { drawlist_add_quad_filled( ptr, p1, p2, p3, p4, col ); }
-	public function addTriangle( p1: ExtDynamic<ImVec2>, p2: ExtDynamic<ImVec2>, p3: ExtDynamic<ImVec2>, col: ImU32, thickness: Single = 1.0 ) { drawlist_add_triangle(ptr, p1, p2, p3, col, thickness ); }
-	public function addTriangleFilled( p1: ExtDynamic<ImVec2>, p2: ExtDynamic<ImVec2>, p3: ExtDynamic<ImVec2>, col: ImU32 ) { drawlist_add_triangle_filled(ptr, p1, p2, p3, col ); }
-	public function addCircle( center: ExtDynamic<ImVec2>, radius: Single, col: ImU32, num_segments: Int = 0, thickness: Single = 1.0 ) { drawlist_add_circle( ptr, center, radius, col, num_segments, thickness ); }
-	public function addCircleFilled( center: ExtDynamic<ImVec2>, radius: Single, col: ImU32, num_segments: Int = 0) { drawlist_add_circle_filled(ptr, center, radius, col, num_segments ); }
-	public function addNgon( center: ExtDynamic<ImVec2>, radius: Single, col: ImU32, num_segments: Int, thickness: Single = 1.0 ) { drawlist_add_ngon(ptr, center, radius, col, num_segments, thickness ); }
-	public function addNgonFilled( center: ExtDynamic<ImVec2>, radius: Single, col: ImU32, num_segments: Int = 0) { drawlist_add_ngon_filled(ptr, center, radius, col, num_segments ); }
-	//public function addPolyLine( points: hl.NativeArray<ImVec2>, col: ImU32, closed: Bool, thickness: Single = 1.0 ) { drawlist_add_poly_line(ptr, points, col, closed, thickness ); }
-	//public function addConvexPolyFilled( points: hl.NativeArray<ExtDynamic<ImVec2>>, col: ImU32 ) { drawlist_add_convex_poly_filled(ptr, points, col ); }
-	public function addBezierCurve( p1: ExtDynamic<ImVec2>, p2: ExtDynamic<ImVec2>, p3: ExtDynamic<ImVec2>, p4: ExtDynamic<ImVec2>, col: ImU32, thickness: Single = 1.0, num_segments: Int = 0 ) { drawlist_add_bezier_curve(ptr, p1, p2, p3, p4, col, thickness, num_segments ); }
+	public function addLine( p1: ImVec2, p2: ImVec2, col: ImU32, thickness: Single = 1.0 ) { drawlist_add_line( this, p1, p2, col, thickness ); }
+	public function addRect( pMin: ImVec2, pMax: ImVec2, col: ImU32, rounding: Single = 0.0, roundingCorners: ImDrawFlags = ImDrawFlags.None, thickness: Single = 1.0 ) { drawlist_add_rect( this, pMin, pMax, col, rounding, roundingCorners, thickness ); }
+	public function addRectFilled( pMin: ImVec2, pMax: ImVec2, col: ImU32, rounding: Single = 0.0, roundingCorners: ImDrawFlags = ImDrawFlags.None ) { drawlist_add_rect_filled( this, pMin, pMax, col, rounding, roundingCorners); }
+	public function addRectFilledMultiColor( pMin: ExtDynamic<ImVec2>, pMax: ExtDynamic<ImVec2>, col_upr_left: ImU32, col_upr_right: ImU32, col_bot_right: ImU32, col_bot_left: ImU32 ) { drawlist_add_rect_filled_multicolor( this, pMin, pMax, col_upr_left, col_upr_right, col_bot_right, col_bot_left ); }
+	public function addQuad( p1: ExtDynamic<ImVec2>, p2: ExtDynamic<ImVec2>, p3: ExtDynamic<ImVec2>, p4: ExtDynamic<ImVec2>, col: ImU32, thickness: Single = 1.0 ) { drawlist_add_quad(this, p1, p2, p3, p4, col, thickness ); }
+	public function addQuadFilled( p1: ExtDynamic<ImVec2>, p2: ExtDynamic<ImVec2>, p3: ExtDynamic<ImVec2>, p4: ExtDynamic<ImVec2>, col: ImU32 ) { drawlist_add_quad_filled( this, p1, p2, p3, p4, col ); }
+	public function addTriangle( p1: ExtDynamic<ImVec2>, p2: ExtDynamic<ImVec2>, p3: ExtDynamic<ImVec2>, col: ImU32, thickness: Single = 1.0 ) { drawlist_add_triangle(this, p1, p2, p3, col, thickness ); }
+	public function addTriangleFilled( p1: ExtDynamic<ImVec2>, p2: ExtDynamic<ImVec2>, p3: ExtDynamic<ImVec2>, col: ImU32 ) { drawlist_add_triangle_filled(this, p1, p2, p3, col ); }
+	public function addCircle( center: ExtDynamic<ImVec2>, radius: Single, col: ImU32, num_segments: Int = 0, thickness: Single = 1.0 ) { drawlist_add_circle( this, center, radius, col, num_segments, thickness ); }
+	public function addCircleFilled( center: ExtDynamic<ImVec2>, radius: Single, col: ImU32, num_segments: Int = 0) { drawlist_add_circle_filled(this, center, radius, col, num_segments ); }
+	public function addNgon( center: ExtDynamic<ImVec2>, radius: Single, col: ImU32, num_segments: Int, thickness: Single = 1.0 ) { drawlist_add_ngon(this, center, radius, col, num_segments, thickness ); }
+	public function addNgonFilled( center: ExtDynamic<ImVec2>, radius: Single, col: ImU32, num_segments: Int = 0) { drawlist_add_ngon_filled(this, center, radius, col, num_segments ); }
+	//public function addPolyLine( points: hl.NativeArray<ImVec2>, col: ImU32, closed: Bool, thickness: Single = 1.0 ) { drawlist_add_poly_line(this, points, col, closed, thickness ); }
+	//public function addConvexPolyFilled( points: hl.NativeArray<ExtDynamic<ImVec2>>, col: ImU32 ) { drawlist_add_convex_poly_filled(this, points, col ); }
+	public function addBezierCurve( p1: ExtDynamic<ImVec2>, p2: ExtDynamic<ImVec2>, p3: ExtDynamic<ImVec2>, p4: ExtDynamic<ImVec2>, col: ImU32, thickness: Single = 1.0, num_segments: Int = 0 ) { drawlist_add_bezier_curve(this, p1, p2, p3, p4, col, thickness, num_segments ); }
 	//
-	public function addText( pos: ImVec2, col: ImU32, text: String ) { drawlist_add_text(ptr, pos, col, text); }
-	public function addText2( font: ImFont, fontSize: Single, pos: ImVec2, col: ImU32, text: String, wrapWidth: Single = 0.0, ?cpuFineClipRect: ImVec4 ) { drawlist_add_text2(ptr, font==null?null:(@:privateAccess font.ptr), fontSize, pos, col, text, wrapWidth, cpuFineClipRect); }
+	public function addText( pos: ImVec2, col: ImU32, text: String ) { drawlist_add_text(this, pos, col, text); }
+	public function addText2( font: ImFont, fontSize: Single, pos: ImVec2, col: ImU32, text: String, wrapWidth: Single = 0.0, ?cpuFineClipRect: ImVec4 ) { drawlist_add_text2(this, font==null?null:(@:privateAccess font.ptr), fontSize, pos, col, text, wrapWidth, cpuFineClipRect); }
 
-	public function addImage( userTextureId: ImTextureID, pMin: ImVec2, pMax: ImVec2, ?uvMin: ImVec2, ?uvMax: ImVec2, col: Int = 0xffffffff ) { drawlist_add_image(ptr, userTextureId, pMin, pMax, uvMin, uvMax, col); }
-	public function addImageQuad( userTextureId: ImTextureID, p1: ImVec2, p2: ImVec2, p3: ImVec2, p4: ImVec2, ?uv1: ImVec2, ?uv2: ImVec2, ?uv3: ImVec2, ?uv4: ImVec2, col: Int = 0xffffffff ) { drawlist_add_image_quad(ptr, userTextureId, p1, p2, p3, p4, uv1, uv2, uv3, uv4, col); }
+	public function addImage( userTextureId: ImTextureID, pMin: ImVec2, pMax: ImVec2, ?uvMin: ImVec2, ?uvMax: ImVec2, col: Int = 0xffffffff ) { drawlist_add_image(this, userTextureId, pMin, pMax, uvMin, uvMax, col); }
+	public function addImageQuad( userTextureId: ImTextureID, p1: ImVec2, p2: ImVec2, p3: ImVec2, p4: ImVec2, ?uv1: ImVec2, ?uv2: ImVec2, ?uv3: ImVec2, ?uv4: ImVec2, col: Int = 0xffffffff ) { drawlist_add_image_quad(this, userTextureId, p1, p2, p3, p4, uv1, uv2, uv3, uv4, col); }
 	// Due to Haxe limitation on defualt parameters being "constant" and enum abstract values that rely on previous enum abstract value (A | B) are not "constant" - hack with -1
-	public function addImageRounded( userTextureId: ImTextureID, pMin: ImVec2, pMax: ImVec2, ?uvMin: ImVec2, ?uvMax: ImVec2, col: Int, rounding: Single, roundingCorners: ImDrawFlags = -1 ) { drawlist_add_image_rounded(ptr, userTextureId, pMin, pMax, uvMin, uvMax, col, rounding, roundingCorners == -1 ? ImDrawFlags.RoundCornersDefault_ : roundingCorners); }
+	public function addImageRounded( userTextureId: ImTextureID, pMin: ImVec2, pMax: ImVec2, ?uvMin: ImVec2, ?uvMax: ImVec2, col: Int, rounding: Single, roundingCorners: ImDrawFlags = -1 ) { drawlist_add_image_rounded(this, userTextureId, pMin, pMax, uvMin, uvMax, col, rounding, roundingCorners == -1 ? ImDrawFlags.RoundCornersDefault_ : roundingCorners); }
 	
 	#if heaps
 	// Helper methods for Heaps: Use Tile instead of Texture to pass image segments easily.
@@ -761,19 +759,19 @@ class ImDrawList
 
 
 @:hlNative("hlimgui")
-class ImFont
+abstract ImFont(ImFontPtr) from ImFontPtr to ImFontPtr
 {
-	var ptr: ImFontPtr;
+	// For backwards compatibility
+	var ptr(get, never): ImFontPtr;
+	inline function get_ptr() return this;
 
-	public function new(ptr: ImFontPtr) { this.ptr = ptr; }
+	public function new(ptr: ImFontPtr) { this = ptr; }
 }
 
 @:hlNative("hlimgui")
-class ImStateStorage
+abstract ImStateStorage(ImStateStoragePtr) from ImStateStoragePtr to ImStateStoragePtr
 {
-	var ptr: ImStateStoragePtr;
-
-	public inline function new(ptr: ImStateStoragePtr) { this.ptr = ptr; }
+	public inline function new(ptr: ImStateStoragePtr) { this = ptr; }
 
 	static function state_storage_get_int(storage: ImStateStoragePtr, id: ImGuiID, default_val: Int): Int { return 0; }
 	static function state_storage_set_int(storage: ImStateStoragePtr, id: ImGuiID, val: Int): Void {}
@@ -782,12 +780,12 @@ class ImStateStorage
 	static function state_storage_get_float(storage: ImStateStoragePtr, id: ImGuiID, default_val: Single): Single { return 0; }
 	static function state_storage_set_float(storage: ImStateStoragePtr, id: ImGuiID, val: Single): Void {}
 
-	public inline function setInt(id: ImGuiID, val: Int):Void state_storage_set_int(ptr, id, val);
-	public inline function getInt(id: ImGuiID, default_val: Int = 0):Int return state_storage_get_int(ptr, id, default_val);
-	public inline function setBool(id: ImGuiID, val: Bool):Void state_storage_set_bool(ptr, id, val);
-	public inline function getBool(id: ImGuiID, default_val: Bool = false):Bool return state_storage_get_bool(ptr, id, default_val);
-	public inline function setFloat(id: ImGuiID, val: Single):Void state_storage_set_float(ptr, id, val);
-	public inline function getFloat(id: ImGuiID, default_val: Single = 0.0):Single return state_storage_get_float(ptr, id, default_val);
+	public inline function setInt(id: ImGuiID, val: Int):Void state_storage_set_int(this, id, val);
+	public inline function getInt(id: ImGuiID, default_val: Int = 0):Int return state_storage_get_int(this, id, default_val);
+	public inline function setBool(id: ImGuiID, val: Bool):Void state_storage_set_bool(this, id, val);
+	public inline function getBool(id: ImGuiID, default_val: Bool = false):Bool return state_storage_get_bool(this, id, default_val);
+	public inline function setFloat(id: ImGuiID, val: Single):Void state_storage_set_float(this, id, val);
+	public inline function getFloat(id: ImGuiID, default_val: Single = 0.0):Single return state_storage_get_float(this, id, default_val);
 }
 
 


### PR DESCRIPTION
* Converted *Ptr types into abstracts - less allocs!
* Fixed odd imgui context shenanigans with turning it into vbyte, and just use an HL abstract.
* Added showStackToolWindow()
* Added getWindowDpiScale() (probably useless)
* Added getFont()
* Renamed pushID2 into pushIDSub and pushID3 into pushIDInt (with backward + deprecation warning)
* Added pushIDPtr() - now possible to hash instances.
* Updates listBox API (deprecations)
* Added valueDouble() because Haxe uses f64.
* Added tabItemButton()
* Changed old Haxe string -> const char* conversions into a convertString macro calls.
* Did some reordering/refactoring of the imgui.hx file to be more in-tune with imgui.h.
* Reworked drag&drop API: Now uses Payload object and ability to pass instances within reason. Now possible to actually use flags like `AcceptBeforeDelivery`. Also possible to peek at the current payload state.