### PR TITLE
Implement better inputText API (pass String)

### DIFF
--- a/extension/utils.h
+++ b/extension/utils.h
@@ -26,6 +26,8 @@
     DEFINE_PRIM(_VOID,set_##name,args)
 
 void convertColor(ImU32 color, float& r, float& g, float& b, float& a);
+int unicodeSizeInUTF8(vstring* hl_string);
+void unicodeToUTF8Buffer(vstring* hl_string, char* out);
 std::string unicodeToUTF8(vstring* hl_string);
 
 void getImGuiFontConfigFromHL(ImFontConfig *imgui_font_config, vdynamic* config);

--- a/extension/widgets_input.cpp
+++ b/extension/widgets_input.cpp
@@ -150,4 +150,4 @@ DEFINE_PRIM(_BOOL, input_double, _STRING _REF(_F64) _REF(_F64) _REF(_F64) _STRIN
 DEFINE_PRIM(_BOOL, input_scalar_n, _STRING _I32 _ARR _DYN _DYN _STRING _I32);
 
 DEFINE_PRIM(_VOID, input_text_callback_delete_chars, _STRUCT _I32 _I32);
-DEFINE_PRIM(_VOID, input_text_callback_insert_chars, _STRUCT _STRING);
+DEFINE_PRIM(_VOID, input_text_callback_insert_chars, _STRUCT _I32 _STRING);

--- a/imgui/ImGui.hx
+++ b/imgui/ImGui.hx
@@ -1206,9 +1206,9 @@ class ImGui
 	static function slider_scalar_n(label : String, type: Int, v : hl.NativeArray<Dynamic>, v_min : Dynamic, v_max : Dynamic, format : String, flags : Int) : Bool {return false;}
 
 	// Widgets: Input with Keyboard
-	public static function inputText(label : String, value: String, flags : ImGuiInputTextFlags = 0, callback: ImGuiInputTextCallbackDataFunc = null) : Bool {return false;}
-	public static function inputTextMultiline(label : String, value: String, size : ExtDynamic<ImVec2> = null, flags : ImGuiInputTextFlags = 0, callback: ImGuiInputTextCallbackDataFunc = null ) : Bool {return false;}
-	public static function inputTextWithHint(label : String, hint : String, value: String, flags : ImGuiInputTextFlags = 0, callback: ImGuiInputTextCallbackDataFunc = null) : Bool {return false;}
+	public static function inputText(label : String, value: hl.Ref<String>, flags : ImGuiInputTextFlags = 0, callback: ImGuiInputTextCallbackDataFunc = null) : Bool {return false;}
+	public static function inputTextMultiline(label : String, value: hl.Ref<String>, size : ExtDynamic<ImVec2> = null, flags : ImGuiInputTextFlags = 0, callback: ImGuiInputTextCallbackDataFunc = null ) : Bool {return false;}
+	public static function inputTextWithHint(label : String, hint : String, value: hl.Ref<String>, flags : ImGuiInputTextFlags = 0, callback: ImGuiInputTextCallbackDataFunc = null) : Bool {return false;}
 	
 	public static function inputTextBuf(label : String, buf : hl.Bytes, buf_size : Int, flags : ImGuiInputTextFlags = 0, callback: ImGuiInputTextCallbackDataFunc = null) : Bool {return false;}
 	public static function inputTextMultilineBuf(label : String, buf : hl.Bytes, buf_size : Int, size : ExtDynamic<ImVec2> = null, flags : ImGuiInputTextFlags = 0, callback: ImGuiInputTextCallbackDataFunc = null ) : Bool {return false;}


### PR DESCRIPTION
* Now inputText* API takes a String as an argument, simplifying management as there's no longer any need in buf/len and UTF8<->UTF16 shenanigans.
* Text callbacks now manage return code.
* Old inputText* API was kept as inputText*Buf variants.
* Fix text callback data alignment.
* Add insert/deleteChars + helpers (insert/delete work in byte positions, helpers allow usage of character positions)