### PR TITLE
Rework fonts, ImVecc and ImDrawList

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,4 @@
 	path = extension/lib/imgui-node-editor
 	url = https://github.com/thedmd/imgui-node-editor.git
 	branch = develop
+	ignore = dirty

--- a/README.md
+++ b/README.md
@@ -32,21 +32,6 @@ Most of the ImGui functionalities are supported and binded. Look at  [https://gi
 
 Here is a list of unsupported features and changes:
 
-- Custom font API is non-standard at the moment.
-```haxe
-var font = ImGui.addFontFromFileTtf("path/to/font.ttf", 14);
-ImGui.buildFont();
-var fontInfo:{buffer:hl.Bytes, width:Int, height:Int} = ImGui.getTexDataAsRgba32();
-
-// create font texture
-var textureSize = fontInfo.width * fontInfo.height * 4;
-var fontTexture = Texture.fromPixels(new hxd.Pixels(
-	fontInfo.width,
-	fontInfo.height,
-	fontInfo.buffer.toBytes(textureSize),
-	hxd.PixelFormat.RGBA));
-ImGui.setFontTexture(fontTexture);
-```
 - As Haxe doesn't support function overloading, so if two original functions have the same name, the second one in Haxe has a suffix `2` to disguish it. For example:
 ```haxe
 public static function treeNode(label : String) : Bool {return false;}

--- a/extension/drawlist.cpp
+++ b/extension/drawlist.cpp
@@ -1,5 +1,9 @@
 #include "utils.h"
 
+#define _TDRAWLIST _ABSTRACT(imdrawlist)
+#define F_NAME(n) HL_NAME(drawlist_##n)
+#define DEFINE_FPRIM(t,name,args) DEFINE_PRIM(t,drawlist_##name,_TDRAWLIST args)
+
 HL_PRIM ImDrawList *HL_NAME(get_window_draw_list)()
 {
     return ImGui::GetWindowDrawList();
@@ -16,181 +20,245 @@ HL_PRIM ImDrawList *HL_NAME(get_background_draw_list)()
 }
 
 // Render-level scissoring. This is passed down to your render function but not used for CPU-side coarse clipping. Prefer using higher-level ImGui::PushClipRect() to affect logic (hit-testing and widget culling)
-HL_PRIM void HL_NAME(drawlist_push_clip_rect)(ImDrawList *drawlist, vdynamic* clip_rect_min, vdynamic* clip_rect_max, bool intersect_with_current_clip_rect) {
+HL_PRIM void F_NAME(push_clip_rect)(ImDrawList *drawlist, vimvec2* clip_rect_min, vimvec2* clip_rect_max, bool intersect_with_current_clip_rect) {
 	drawlist->PushClipRect(clip_rect_min, clip_rect_max, intersect_with_current_clip_rect);
 }
 
-HL_PRIM void HL_NAME(drawlist_push_clip_rect_full_screen)(ImDrawList* drawlist) {
+HL_PRIM void F_NAME(push_clip_rect_full_screen)(ImDrawList* drawlist) {
 	drawlist->PushClipRectFullScreen();
 }
 
-HL_PRIM void HL_NAME(drawlist_pop_clip_rect)(ImDrawList* drawlist) {
+HL_PRIM void F_NAME(pop_clip_rect)(ImDrawList* drawlist) {
 	drawlist->PopClipRect();
 }
 
-HL_PRIM void HL_NAME(drawlist_push_texture_id)(ImDrawList* drawlist, ImTextureID texture_id) {
+HL_PRIM void F_NAME(push_texture_id)(ImDrawList* drawlist, ImTextureID texture_id) {
 	drawlist->PushTextureID(texture_id);
 }
 
-HL_PRIM void HL_NAME(drawlist_pop_texture_id)(ImDrawList* drawlist) {
+HL_PRIM void F_NAME(pop_texture_id)(ImDrawList* drawlist) {
 	drawlist->PopTextureID();
 }
 
-HL_PRIM vdynamic* HL_NAME(drawlist_get_clip_rect_min)(ImDrawList* drawlist) {
+HL_PRIM vimvec2* F_NAME(get_clip_rect_min)(ImDrawList* drawlist) {
 	return drawlist->GetClipRectMin();
 }
 
-HL_PRIM vdynamic* HL_NAME(drawlist_get_clip_rect_max)(ImDrawList* drawlist) {
+HL_PRIM vimvec2* F_NAME(get_clip_rect_max)(ImDrawList* drawlist) {
 	return drawlist->GetClipRectMax();
 }
 
-HL_PRIM void HL_NAME(drawlist_add_line)(ImDrawList *drawlist, vdynamic* p1, vdynamic* p2, ImU32 col, float thickness)
+HL_PRIM void F_NAME(add_line)(ImDrawList *drawlist, vimvec2* p1, vimvec2* p2, ImU32 col, float thickness)
 {
-	drawlist->AddLine( getImVec2(p1), getImVec2(p2), col, thickness );
+	drawlist->AddLine( p1, p2, col, thickness );
 }
 
-HL_PRIM void HL_NAME(drawlist_add_rect)(ImDrawList *drawlist, vdynamic* p_min, vdynamic* p_max, ImU32 col, float rounding, ImDrawFlags rounding_corners, float thickness)
+HL_PRIM void F_NAME(add_rect)(ImDrawList *drawlist, vimvec2* p_min, vimvec2* p_max, ImU32 col, float rounding, ImDrawFlags rounding_corners, float thickness)
 {
-	drawlist->AddRect( getImVec2(p_min), getImVec2(p_max), col, rounding, rounding_corners, thickness );
+	drawlist->AddRect( p_min, p_max, col, rounding, rounding_corners, thickness );
 }
 
-HL_PRIM void HL_NAME(drawlist_add_rect_filled)(ImDrawList *drawlist, vdynamic* p_min, vdynamic* p_max, ImU32 col, float rounding, ImDrawFlags rounding_corners)
+HL_PRIM void F_NAME(add_rect_filled)(ImDrawList *drawlist, vimvec2* p_min, vimvec2* p_max, ImU32 col, float rounding, ImDrawFlags rounding_corners)
 {
-	drawlist->AddRectFilled( getImVec2(p_min), getImVec2(p_max), col, rounding, rounding_corners );
+	drawlist->AddRectFilled( p_min, p_max, col, rounding, rounding_corners );
 }
 
-HL_PRIM void HL_NAME(drawlist_add_rect_filled_multicolor)( ImDrawList *drawlist, vdynamic* p_min, vdynamic* p_max, ImU32 col_upr_left , ImU32 col_upr_right, ImU32 col_bot_right, ImU32 col_bot_left)
+HL_PRIM void F_NAME(add_rect_filled_multi_color)( ImDrawList *drawlist, vimvec2* p_min, vimvec2* p_max, ImU32 col_upr_left , ImU32 col_upr_right, ImU32 col_bot_right, ImU32 col_bot_left)
 {
-	drawlist->AddRectFilledMultiColor( getImVec2(p_min), getImVec2(p_max), col_upr_left, col_upr_right, col_bot_right, col_bot_left );
+	drawlist->AddRectFilledMultiColor( p_min, p_max, col_upr_left, col_upr_right, col_bot_right, col_bot_left );
 }
 
-HL_PRIM void HL_NAME(drawlist_add_quad)(ImDrawList *drawlist, vdynamic* p1, vdynamic* p2, vdynamic* p3, vdynamic* p4, ImU32 col, float thickness)
+HL_PRIM void F_NAME(add_quad)(ImDrawList *drawlist, vimvec2* p1, vimvec2* p2, vimvec2* p3, vimvec2* p4, ImU32 col, float thickness)
 {
-	drawlist->AddQuad( getImVec2(p1), getImVec2(p2), getImVec2(p3), getImVec2(p4), col, thickness );
+	drawlist->AddQuad( p1, p2, p3, p4, col, thickness );
 }
 
-HL_PRIM void HL_NAME(drawlist_add_quad_filled)(ImDrawList *drawlist, vdynamic* p1, vdynamic* p2, vdynamic* p3, vdynamic* p4, ImU32 col)
+HL_PRIM void F_NAME(add_quad_filled)(ImDrawList *drawlist, vimvec2* p1, vimvec2* p2, vimvec2* p3, vimvec2* p4, ImU32 col)
 {
-	drawlist->AddQuadFilled( getImVec2(p1), getImVec2(p2), getImVec2(p3), getImVec2(p4), col );
+	drawlist->AddQuadFilled(p1, p2, p3, p4, col );
 }
 
-HL_PRIM void HL_NAME(drawlist_add_triangle)(ImDrawList *drawlist, vdynamic* p1, vdynamic* p2, vdynamic* p3, ImU32 col, float thickness)
+HL_PRIM void F_NAME(add_triangle)(ImDrawList *drawlist, vimvec2* p1, vimvec2* p2, vimvec2* p3, ImU32 col, float thickness)
 {
-	drawlist->AddTriangle( getImVec2(p1), getImVec2(p2), getImVec2(p3), col, thickness );
+	drawlist->AddTriangle( p1, p2, p3, col, thickness );
 }
 
-HL_PRIM void HL_NAME(drawlist_add_triangle_filled)(ImDrawList *drawlist, vdynamic* p1, vdynamic* p2, vdynamic* p3, ImU32 col)
+HL_PRIM void F_NAME(add_triangle_filled)(ImDrawList *drawlist, vimvec2* p1, vimvec2* p2, vimvec2* p3, ImU32 col)
 {
-	drawlist->AddTriangleFilled( getImVec2(p1), getImVec2(p2), getImVec2(p3), col );
+	drawlist->AddTriangleFilled( p1, p2, p3, col );
 }
 
-HL_PRIM void HL_NAME(drawlist_add_circle)(ImDrawList *drawlist, vdynamic* center, float radius, ImU32 col, int num_segments, float thickness)
+HL_PRIM void F_NAME(add_circle)(ImDrawList *drawlist, vimvec2* center, float radius, ImU32 col, int num_segments, float thickness)
 {
-	drawlist->AddCircle( getImVec2(center), radius, col, num_segments, thickness );
+	drawlist->AddCircle( center, radius, col, num_segments, thickness );
 }
 
-HL_PRIM void HL_NAME(drawlist_add_circle_filled)(ImDrawList *drawlist, vdynamic* center, float radius, ImU32 col, int num_segments)
+HL_PRIM void F_NAME(add_circle_filled)(ImDrawList *drawlist, vimvec2* center, float radius, ImU32 col, int num_segments)
 {
-	drawlist->AddCircleFilled( getImVec2(center), radius, col, num_segments );
+	drawlist->AddCircleFilled( center, radius, col, num_segments );
 }
 
-HL_PRIM void HL_NAME(drawlist_add_ngon)(ImDrawList *drawlist, vdynamic* center, float radius, ImU32 col, int num_segments, float thickness)
+HL_PRIM void F_NAME(add_ngon)(ImDrawList *drawlist, vimvec2* center, float radius, ImU32 col, int num_segments, float thickness)
 {
-	drawlist->AddNgon( getImVec2(center), radius, col, num_segments, thickness );
+	drawlist->AddNgon( center, radius, col, num_segments, thickness );
 }
 
-HL_PRIM void HL_NAME(drawlist_add_ngon_filled)(ImDrawList *drawlist, vdynamic* center, float radius, ImU32 col, int num_segments)
+HL_PRIM void F_NAME(add_ngon_filled)(ImDrawList *drawlist, vimvec2* center, float radius, ImU32 col, int num_segments)
 {
-	drawlist->AddNgonFilled( getImVec2(center), radius, col, num_segments );
+	drawlist->AddNgonFilled( center, radius, col, num_segments );
 }
 
-HL_PRIM void HL_NAME(drawlist_add_poly_line)(ImDrawList *drawlist, varray* points, ImU32 col, bool closed, float thickness)
+HL_PRIM void F_NAME(add_poly_line)(ImDrawList *drawlist, varray* points, ImU32 col, bool closed, float thickness)
 {
 	std::vector<ImVec2> vecPoints;
+	auto hlPoints = hl_aptr(points, vimvec2*);
 	for (int i = 0; i < points->size; i++)
-    {
-        vecPoints.push_back(getImVec2(hl_aptr(points, vdynamic*)[i]));
-    }
+	{
+		vecPoints.push_back(hlPoints[i]);
+	}
 
 	drawlist->AddPolyline( &vecPoints[0], points->size, col, closed, thickness );
 }
 
-HL_PRIM void HL_NAME(drawlist_add_convex_poly_filled)(ImDrawList *drawlist, varray* points, ImU32 col)
+HL_PRIM void F_NAME(add_convex_poly_filled)(ImDrawList *drawlist, varray* points, ImU32 col)
 {
 	std::vector<ImVec2> vecPoints;
+	auto hlPoints = hl_aptr(points, vimvec2*);
 	for (int i = 0; i < points->size; i++)
-    {
-        vecPoints.push_back(getImVec2(hl_aptr(points, vdynamic*)[i]));
-    }
+	{
+		vecPoints.push_back(hlPoints[i]);
+	}
 
 	drawlist->AddConvexPolyFilled( &vecPoints[0], points->size, col);
 }
 
-HL_PRIM void HL_NAME(drawlist_add_bezier_curve)(ImDrawList *drawlist, vdynamic* p1, vdynamic* p2, vdynamic* p3, vdynamic* p4, ImU32 col, float thickness, int num_segments)
+HL_PRIM void F_NAME(add_bezier_curve)(ImDrawList *drawlist, vimvec2* p1, vimvec2* p2, vimvec2* p3, vimvec2* p4, ImU32 col, float thickness, int num_segments)
 {
-	drawlist->AddBezierCurve( getImVec2(p1), getImVec2(p2), getImVec2(p3), getImVec2(p4), col, thickness, num_segments );
+	drawlist->AddBezierCurve( p1, p2, p3, p4, col, thickness, num_segments );
 }
 
-HL_PRIM void HL_NAME(drawlist_add_text)(ImDrawList* drawlist, vdynamic* pos, int col, vstring* text) {
+HL_PRIM void F_NAME(add_text)(ImDrawList* drawlist, vimvec2* pos, int col, vstring* text) {
 	drawlist->AddText(pos, col, convertString(text));
 }
 
-HL_PRIM void HL_NAME(drawlist_add_text2)(ImDrawList* drawlist, ImFont* font, float font_size, vdynamic* pos, int col, vstring* text, float wrap_width, vdynamic* cpu_fine_clip_rect) {
-	ImVec4 clip = cpu_fine_clip_rect == nullptr ? NULL : ImVec4(cpu_fine_clip_rect);
-	drawlist->AddText(font, font_size, ImVec2(pos), col, convertString(text), (const char*)NULL, wrap_width, &clip);
+HL_PRIM void F_NAME(add_text2)(ImDrawList* drawlist, ImFont* font, float font_size, vimvec2* pos, int col, vstring* text, float wrap_width, vimvec4* cpu_fine_clip_rect) {
+	ImVec4 clip = cpu_fine_clip_rect == nullptr ? NULL : cpu_fine_clip_rect;
+	drawlist->AddText(font, font_size, pos, col, convertString(text), (const char*)NULL, wrap_width, &clip);
 }
 
-HL_PRIM void HL_NAME(drawlist_add_image)(ImDrawList* drawlist, ImTextureID user_texture_id, vdynamic* p_min, vdynamic* p_max, vdynamic* uv_min, vdynamic* uv_max, int col) {
-	drawlist->AddImage(user_texture_id, p_min, p_max, getImVec2(uv_min), getImVec2(uv_max, ImVec2(1, 1)),  col);
+HL_PRIM void F_NAME(add_image)(ImDrawList* drawlist, ImTextureID user_texture_id, vimvec2* p_min, vimvec2* p_max, vimvec2* uv_min, vimvec2* uv_max, int col) {
+	drawlist->AddImage(user_texture_id, p_min, p_max, convertVec(uv_min, ImVec2(0, 0)), convertVec(uv_max, ImVec2(1, 1)), col);
 }
 
-HL_PRIM void HL_NAME(drawlist_add_image_quad)(ImDrawList* drawlist, ImTextureID user_texture_id, vdynamic* p1, vdynamic* p2, vdynamic* p3, vdynamic* p4, vdynamic* uv1, vdynamic* uv2, vdynamic* uv3, vdynamic* uv4, int col) {
+HL_PRIM void F_NAME(add_image_quad)(ImDrawList* drawlist, ImTextureID user_texture_id, vimvec2* p1, vimvec2* p2, vimvec2* p3, vimvec2* p4, vimvec2* uv1, vimvec2* uv2, vimvec2* uv3, vimvec2* uv4, int col) {
 	drawlist->AddImageQuad(user_texture_id, 
 		p1, p2, p3, p4,
-		getImVec2(uv1), getImVec2(uv2, ImVec2(1, 0)), getImVec2(uv3, ImVec2(1, 1)), getImVec2(uv4, ImVec2(0, 1)),
-		col);
+		convertVec(uv1, ImVec2(0, 0)), convertVec(uv2, ImVec2(1, 0)), convertVec(uv3, ImVec2(1, 1)), convertVec(uv4, ImVec2(0, 1)),
+		col
+	);
 }
 
-HL_PRIM void HL_NAME(drawlist_add_image_rounded)(ImDrawList *drawlist, ImTextureID user_texture_id, vdynamic* p_min, vdynamic* p_max, vdynamic* uv_min, vdynamic* uv_max, int col, float rounding, ImDrawFlags flags) {
-	drawlist->AddImageRounded(user_texture_id, p_min, p_max, getImVec2(uv_min), getImVec2(uv_max, ImVec2(1, 1)), col, rounding, flags);
+HL_PRIM void F_NAME(add_image_rounded)(ImDrawList *drawlist, ImTextureID user_texture_id, vimvec2* p_min, vimvec2* p_max, vimvec2* uv_min, vimvec2* uv_max, int col, float rounding, ImDrawFlags flags) {
+	drawlist->AddImageRounded(user_texture_id, p_min, p_max, uv_min, uv_max, col, rounding, flags);
 }
 
-#define _TDRAWLIST _ABSTRACT(imdrawlist)
+
+// Stateful path API, add points then finish with PathFillConvex() or PathStroke()
+HL_PRIM void F_NAME(path_clear)(ImDrawList* drawlist)
+{
+	drawlist->PathClear();
+}
+
+HL_PRIM void F_NAME(path_line_to)(ImDrawList* drawlist, vimvec2* pos)
+{
+	drawlist->PathLineTo(pos);
+}
+
+HL_PRIM void F_NAME(path_line_to_merge_duplicate)(ImDrawList* drawlist, vimvec2* pos)
+{
+	drawlist->PathLineToMergeDuplicate(pos);
+}
+
+HL_PRIM void F_NAME(path_fill_convex)(ImDrawList* drawlist, int col)
+{
+	drawlist->PathFillConvex(col);
+}
+
+HL_PRIM void F_NAME(path_stroke)(ImDrawList* drawlist, int col, ImDrawFlags flags, float thickness)
+{
+	drawlist->PathStroke(col, flags, thickness);
+}
+
+HL_PRIM void F_NAME(path_arc_to)(ImDrawList* drawlist, vimvec2* center, float radius, float a_min, float a_max, int num_segments)
+{
+	drawlist->PathArcTo(center, radius, a_min, a_max, num_segments);
+}
+
+HL_PRIM void F_NAME(path_arc_to_fast)(ImDrawList* drawlist, vimvec2* center, float radius, int a_min_of_12, int a_max_of_12)
+{
+	drawlist->PathArcToFast(center, radius, a_min_of_12, a_max_of_12);
+}
+
+HL_PRIM void F_NAME(path_bezier_cubic_curve_to)(ImDrawList* drawlist, vimvec2* p2, vimvec2* p3, vimvec2* p4, int num_segments)
+{
+	drawlist->PathBezierCubicCurveTo(p2, p3, p4, num_segments);
+}
+
+HL_PRIM void F_NAME(path_bezier_quadratic_curve_to)(ImDrawList* drawlist, vimvec2* p2, vimvec2* p3, int num_segments)
+{
+	drawlist->PathBezierQuadraticCurveTo(p2, p3, num_segments);
+}
+
+HL_PRIM void F_NAME(path_rect)(ImDrawList* drawlist, vimvec2* rect_min, vimvec2* rect_max, float rounding, ImDrawFlags flags)
+{
+	drawlist->PathRect(rect_min, rect_max, rounding, flags);
+}
 
 DEFINE_PRIM(_TDRAWLIST, get_window_draw_list, _NO_ARG );
 DEFINE_PRIM(_TDRAWLIST, get_foreground_draw_list, _NO_ARG );
 DEFINE_PRIM(_TDRAWLIST, get_background_draw_list, _NO_ARG );
 
-DEFINE_PRIM(_VOID, drawlist_push_clip_rect, _TDRAWLIST _DYN _DYN _BOOL);
-DEFINE_PRIM(_VOID, drawlist_push_clip_rect_full_screen, _TDRAWLIST);
-DEFINE_PRIM(_VOID, drawlist_pop_clip_rect, _TDRAWLIST);
-DEFINE_PRIM(_VOID, drawlist_push_texture_id, _TDRAWLIST _DYN);
-DEFINE_PRIM(_VOID, drawlist_pop_texture_id, _TDRAWLIST);
-DEFINE_PRIM(_DYN, drawlist_get_clip_rect_min, _TDRAWLIST);
-DEFINE_PRIM(_DYN, drawlist_get_clip_rect_max, _TDRAWLIST);
+DEFINE_FPRIM(_VOID, push_clip_rect, _IMVEC2 _IMVEC2 _BOOL);
+DEFINE_FPRIM(_VOID, push_clip_rect_full_screen, _NO_ARG);
+DEFINE_FPRIM(_VOID, pop_clip_rect, _NO_ARG);
+DEFINE_FPRIM(_VOID, push_texture_id, _DYN);
+DEFINE_FPRIM(_VOID, pop_texture_id, _NO_ARG);
+DEFINE_FPRIM(_IMVEC2, get_clip_rect_min, _NO_ARG);
+DEFINE_FPRIM(_IMVEC2, get_clip_rect_max, _NO_ARG);
 
-DEFINE_PRIM(_VOID, drawlist_add_line, _TDRAWLIST _DYN _DYN _I32 _F32 );
-DEFINE_PRIM(_VOID, drawlist_add_rect, _TDRAWLIST _DYN _DYN _I32 _F32 _I32 _F32 );
-DEFINE_PRIM(_VOID, drawlist_add_rect_filled, _TDRAWLIST _DYN _DYN _I32 _F32 _I32 );
-DEFINE_PRIM(_VOID, drawlist_add_rect_filled_multicolor, _TDRAWLIST _DYN _DYN _I32 _I32 _I32 _I32 );
-DEFINE_PRIM(_VOID, drawlist_add_quad, _TDRAWLIST _DYN _DYN _DYN _DYN _I32 _F32 );
-DEFINE_PRIM(_VOID, drawlist_add_quad_filled, _TDRAWLIST _DYN _DYN _DYN _DYN _I32 );
-DEFINE_PRIM(_VOID, drawlist_add_triangle, _TDRAWLIST _DYN _DYN _DYN _I32 _F32 );
-DEFINE_PRIM(_VOID, drawlist_add_triangle_filled, _TDRAWLIST _DYN _DYN _DYN _I32 );
-DEFINE_PRIM(_VOID, drawlist_add_circle, _TDRAWLIST _DYN _F32 _I32 _I32 _F32 );
-DEFINE_PRIM(_VOID, drawlist_add_circle_filled, _TDRAWLIST _DYN _F32 _I32 _I32 );
-DEFINE_PRIM(_VOID, drawlist_add_ngon, _TDRAWLIST _DYN _F32 _I32 _I32 _F32 );
-DEFINE_PRIM(_VOID, drawlist_add_ngon_filled, _TDRAWLIST _DYN _F32 _I32 _I32 );
-DEFINE_PRIM(_VOID, drawlist_add_poly_line, _TDRAWLIST _ARR _I32 _BOOL _F32 );
-DEFINE_PRIM(_VOID, drawlist_add_convex_poly_filled, _TDRAWLIST _ARR _I32  );
-DEFINE_PRIM(_VOID, drawlist_add_bezier_curve, _TDRAWLIST _DYN _DYN _DYN _DYN _I32 _F32 _I32 );
+DEFINE_FPRIM(_VOID, add_line, _IMVEC2 _IMVEC2 _I32 _F32 );
+DEFINE_FPRIM(_VOID, add_rect, _IMVEC2 _IMVEC2 _I32 _F32 _I32 _F32 );
+DEFINE_FPRIM(_VOID, add_rect_filled, _IMVEC2 _IMVEC2 _I32 _F32 _I32 );
+DEFINE_FPRIM(_VOID, add_rect_filled_multi_color, _IMVEC2 _IMVEC2 _I32 _I32 _I32 _I32 );
+DEFINE_FPRIM(_VOID, add_quad, _IMVEC2 _IMVEC2 _IMVEC2 _IMVEC2 _I32 _F32 );
+DEFINE_FPRIM(_VOID, add_quad_filled, _IMVEC2 _IMVEC2 _IMVEC2 _IMVEC2 _I32 );
+DEFINE_FPRIM(_VOID, add_triangle, _IMVEC2 _IMVEC2 _IMVEC2 _I32 _F32 );
+DEFINE_FPRIM(_VOID, add_triangle_filled, _IMVEC2 _IMVEC2 _IMVEC2 _I32 );
+DEFINE_FPRIM(_VOID, add_circle, _IMVEC2 _F32 _I32 _I32 _F32 );
+DEFINE_FPRIM(_VOID, add_circle_filled, _IMVEC2 _F32 _I32 _I32 );
+DEFINE_FPRIM(_VOID, add_ngon, _IMVEC2 _F32 _I32 _I32 _F32 );
+DEFINE_FPRIM(_VOID, add_ngon_filled, _IMVEC2 _F32 _I32 _I32 );
+DEFINE_FPRIM(_VOID, add_poly_line, _ARR _I32 _BOOL _F32 );
+DEFINE_FPRIM(_VOID, add_convex_poly_filled, _ARR _I32  );
+DEFINE_FPRIM(_VOID, add_bezier_curve, _IMVEC2 _IMVEC2 _IMVEC2 _IMVEC2 _I32 _F32 _I32 );
 //
-DEFINE_PRIM(_VOID, drawlist_add_text, _TDRAWLIST _DYN _I32 _STRING);
-DEFINE_PRIM(_VOID, drawlist_add_text2, _TDRAWLIST _ABSTRACT(imfont) _F32 _DYN _I32 _STRING _F32 _DYN);
+DEFINE_FPRIM(_VOID, add_text, _IMVEC2 _I32 _STRING);
+DEFINE_FPRIM(_VOID, add_text2, _ABSTRACT(imfont) _F32 _IMVEC2 _I32 _STRING _F32 _IMVEC4);
 
-DEFINE_PRIM(_VOID, drawlist_add_image, _TDRAWLIST _DYN _DYN _DYN _DYN _DYN _I32 );
-DEFINE_PRIM(_VOID, drawlist_add_image_quad, _TDRAWLIST _DYN _DYN _DYN _DYN _DYN _DYN _DYN _DYN _DYN _I32 );
-DEFINE_PRIM(_VOID, drawlist_add_image_rounded, _TDRAWLIST _DYN _DYN _DYN _DYN _DYN _I32 _F32 _I32 );
+DEFINE_FPRIM(_VOID, add_image, _DYN _IMVEC2 _IMVEC2 _IMVEC2 _IMVEC2 _I32 );
+DEFINE_FPRIM(_VOID, add_image_quad, _DYN _IMVEC2 _IMVEC2 _IMVEC2 _IMVEC2 _IMVEC2 _IMVEC2 _IMVEC2 _IMVEC2 _I32 );
+DEFINE_FPRIM(_VOID, add_image_rounded, _DYN _IMVEC2 _IMVEC2 _IMVEC2 _IMVEC2 _I32 _F32 _I32 );
+
+DEFINE_FPRIM(_VOID, path_clear, _NO_ARG);
+DEFINE_FPRIM(_VOID, path_line_to, _IMVEC2);
+DEFINE_FPRIM(_VOID, path_line_to_merge_duplicate, _IMVEC2);
+DEFINE_FPRIM(_VOID, path_fill_convex, _I32);
+DEFINE_FPRIM(_VOID, path_stroke, _I32 _I32 _F32);
+DEFINE_FPRIM(_VOID, path_arc_to, _IMVEC2 _F32 _F32 _F32 _I32);
+DEFINE_FPRIM(_VOID, path_arc_to_fast, _IMVEC2 _F32 _I32 _I32);
+DEFINE_FPRIM(_VOID, path_bezier_cubic_curve_to, _IMVEC2 _IMVEC2 _IMVEC2 _I32);
+DEFINE_FPRIM(_VOID, path_bezier_quadratic_curve_to, _IMVEC2 _IMVEC2 _I32);
+DEFINE_FPRIM(_VOID, path_rect, _IMVEC2 _IMVEC2 _F32 _I32);
 
 
 

--- a/extension/font.cpp
+++ b/extension/font.cpp
@@ -108,9 +108,9 @@ HL_PRIM int F_NAME(add_custom_rect_regular)(ImFontAtlas* fonts, int width, int h
 	return fonts->AddCustomRectRegular(width, height);
 }
 
-HL_PRIM int F_NAME(add_custom_rect_font_glyph)(ImFontAtlas* fonts, ImFont* font, ImWchar id, int width, int height, float advance_x, ImVec2* offset)
+HL_PRIM int F_NAME(add_custom_rect_font_glyph)(ImFontAtlas* fonts, ImFont* font, ImWchar id, int width, int height, float advance_x, vimvec2* offset)
 {
-	return fonts->AddCustomRectFontGlyph(font, id, width, height, advance_x, offset == nullptr ? ImVec2(0, 0) : *offset);
+	return fonts->AddCustomRectFontGlyph(font, id, width, height, advance_x, offset != nullptr ? offset->v : ImVec2(0, 0));
 }
 
 HL_PRIM ImFontAtlasCustomRect* F_NAME(get_custom_rect_by_index)(ImFontAtlas* fonts, int index)
@@ -118,23 +118,23 @@ HL_PRIM ImFontAtlasCustomRect* F_NAME(get_custom_rect_by_index)(ImFontAtlas* fon
 	return fonts->GetCustomRectByIndex(index);
 }
 
-HL_PRIM void F_NAME(calc_custom_rect_uv)(ImFontAtlas* fonts, ImFontAtlasCustomRect* rect, ImVec2* out_uv_min, ImVec2* out_uv_max)
+HL_PRIM void F_NAME(calc_custom_rect_uv)(ImFontAtlas* fonts, ImFontAtlasCustomRect* rect, vimvec2* out_uv_min, vimvec2* out_uv_max)
 {
-	return fonts->CalcCustomRectUV(rect, out_uv_min, out_uv_max);
+	return fonts->CalcCustomRectUV(rect, &out_uv_min->v, &out_uv_max->v);
 }
 
 typedef struct {
 	hl_type* t;
-	ImVec2* offset;
-	ImVec2* size;
-	ImVec4* uv_border; // xy = min, zw = max
-	ImVec4* uv_fill; // xy = min, zw = max
+	vimvec2* offset;
+	vimvec2* size;
+	vimvec4* uv_border; // xy = min, zw = max
+	vimvec4* uv_fill; // xy = min, zw = max
 } vcursordata;
 #define _CURSORDATA _OBJ(_IMVEC2 _IMVEC2 _IMVEC4 _IMVEC4)
 
 HL_PRIM bool F_NAME(get_mouse_cursor_tex_data)(ImFontAtlas* fonts, ImGuiMouseCursor cursor, vcursordata* output)
 {
-	return fonts->GetMouseCursorTexData(cursor, output->offset, output->size, (ImVec2*)output->uv_border, (ImVec2*)output->uv_fill);
+	return fonts->GetMouseCursorTexData(cursor, &output->offset->v, &output->size->v, (&output->uv_border->min), (&output->uv_fill->min));
 }
 
 HL_PRIM void HL_NAME(push_font)(ImFont *font)

--- a/extension/font.cpp
+++ b/extension/font.cpp
@@ -1,86 +1,186 @@
 #include "utils.h"
 
-HL_PRIM ImFont *HL_NAME(add_font_default)(vdynamic* config)
-{
-    ImFontConfig cfg = ImFontConfig();
-    if ( config != nullptr )
-        getImGuiFontConfigFromHL( &cfg, config );
+#define _TFONTATLAS _ABSTRACT(imfontatlas)
+#define _TFONT _ABSTRACT(imfont)
+#define F_NAME(n) HL_NAME(imfontatlas_##n)
+#define DEFINE_FPRIM(t,name,args) DEFINE_PRIM(t,imfontatlas_##name,_TFONTATLAS args)
 
-    return ImGui::GetIO().Fonts->AddFontDefault(&cfg);
+HL_PRIM ImFontAtlas* HL_NAME(get_font_atlas)()
+{
+	return ImGui::GetIO().Fonts;
 }
 
-HL_PRIM ImFont *HL_NAME(add_font_from_memory_ttf)(vbyte* font_data, int font_size, float size_pixels, vdynamic* config, varray* ranges)
+HL_PRIM ImFont* F_NAME(add_font)(ImFontAtlas* fonts, ImFontConfig* font_cfg)
 {
-    ImFontConfig cfg = ImFontConfig();
-    if( config != nullptr )
-        getImGuiFontConfigFromHL( &cfg, config );
-
-    ImWchar *glyph_ranges = ranges != nullptr ? hl_aptr(ranges,ImWchar) : nullptr;
-
-    return ImGui::GetIO().Fonts->AddFontFromMemoryTTF( font_data, font_size, size_pixels, &cfg, glyph_ranges );
+	return fonts->AddFont(font_cfg);
 }
 
-HL_PRIM ImFont *HL_NAME(add_font_from_file_ttf)(vstring* filename, float size, vdynamic* config, varray* ranges )
+HL_PRIM ImFont* F_NAME(add_font_default)(ImFontAtlas* fonts, ImFontConfig* font_cfg)
 {
-    ImFontConfig cfg = ImFontConfig();
-    if( config != nullptr )
-        getImGuiFontConfigFromHL( &cfg, config );
-
-    ImWchar *glyph_ranges = ranges != nullptr ? hl_aptr(ranges,ImWchar) : nullptr;
-
-    return ImGui::GetIO().Fonts->AddFontFromFileTTF( convertString( filename ), size, &cfg, glyph_ranges );
+	return fonts->AddFontDefault(font_cfg);
 }
 
-HL_PRIM vdynamic *HL_NAME(get_tex_data_as_rgba32)(vstring* filename, float size)
+HL_PRIM ImFont* F_NAME(add_font_from_file_ttf)(ImFontAtlas* fonts, vstring* filename, float size_pixels, ImFontConfig* font_cfg, varray* glyph_ranges)
 {
-    unsigned char* pixels;
-    int width, height;
-    ImGuiIO& io = ImGui::GetIO();
+	return fonts->AddFontFromFileTTF(convertString(filename), size_pixels, font_cfg, convertArray(glyph_ranges, ImWchar));
+}
 
-    io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);
+HL_PRIM ImFont* F_NAME(add_font_from_memory_ttf)(ImFontAtlas* fonts, vbyte* font_data, int font_size, float size_pixels, ImFontConfig* font_cfg, varray* glyph_ranges)
+{
+	// Because font_data is allocated on GC, we want to ensure font builder won't free it.
+	if (font_cfg == nullptr) {
+		ImFontConfig cfg = ImFontConfig();
+		cfg.FontDataOwnedByAtlas = false;
+		return fonts->AddFontFromMemoryTTF(font_data, font_size, size_pixels, &cfg, convertArray(glyph_ranges, ImWchar));
+	} else {
+		font_cfg->FontDataOwnedByAtlas = false;
+		return fonts->AddFontFromMemoryTTF(font_data, font_size, size_pixels, font_cfg, convertArray(glyph_ranges, ImWchar));
+	}
+}
 
-    IM_ASSERT( width != 0 && height != 0 && "Invalid texture generated, bad font?");
+// TODO: AddFontFromMemoryCompressedTTF
+// TODO: AddFontFromMemoryCompressedBase85TTF
 
-    vbyte* buffer = hl_copy_bytes(pixels, width*height*4);
+HL_PRIM void F_NAME(clear_input_data)(ImFontAtlas* fonts)
+{
+	fonts->ClearInputData();
+}
 
-    vdynamic* font_info = (vdynamic*)hl_alloc_dynobj();
-    hl_dyn_setp(font_info, hl_hash_utf8("buffer"), &hlt_bytes, buffer);
-    hl_dyn_seti(font_info, hl_hash_utf8("width"), &hlt_i32, width);
-    hl_dyn_seti(font_info, hl_hash_utf8("height"), &hlt_i32, height);
+HL_PRIM void F_NAME(clear_tex_data)(ImFontAtlas* fonts)
+{
+	fonts->ClearTexData();
+}
 
-    io.Fonts->ClearTexData();
+HL_PRIM void F_NAME(clear_fonts)(ImFontAtlas* fonts)
+{
+	fonts->ClearFonts();
+}
 
-    return font_info;
+HL_PRIM void F_NAME(clear)(ImFontAtlas* fonts)
+{
+	fonts->Clear();
+}
+
+HL_PRIM bool F_NAME(build)(ImFontAtlas* fonts)
+{
+	return fonts->Build();
+}
+
+typedef struct {
+	hl_type* t;
+	vbyte* buffer;
+	int width;
+	int height;
+	int bytesPerPixel;
+} vtexdata;
+#define _TEXDATA _OBJ(_BYTES _I32 _I32 _I32)
+
+HL_PRIM void F_NAME(get_tex_data_as_alpha8)(ImFontAtlas* fonts, vtexdata* output)
+{
+	unsigned char* pixels;
+	
+	fonts->GetTexDataAsAlpha8(&pixels, &output->width, &output->height, &output->bytesPerPixel);
+	output->buffer = hl_copy_bytes(pixels, output->width * output->height * output->bytesPerPixel);
+}
+
+HL_PRIM void F_NAME(get_tex_data_as_rgba32)(ImFontAtlas* fonts, vtexdata* output)
+{
+	unsigned char* pixels;
+	
+	fonts->GetTexDataAsRGBA32(&pixels, &output->width, &output->height, &output->bytesPerPixel);
+	output->buffer = hl_copy_bytes(pixels, output->width * output->height * output->bytesPerPixel);
+}
+
+HL_PRIM bool F_NAME(is_built)(ImFontAtlas* fonts)
+{
+	return fonts->IsBuilt();
+}
+
+HL_PRIM void F_NAME(set_tex_id)(ImFontAtlas* fonts, ImTextureID id)
+{
+	fonts->SetTexID(id);
+}
+
+// TODO: GetGlyphRangesX();
+
+HL_PRIM int F_NAME(add_custom_rect_regular)(ImFontAtlas* fonts, int width, int height)
+{
+	return fonts->AddCustomRectRegular(width, height);
+}
+
+HL_PRIM int F_NAME(add_custom_rect_font_glyph)(ImFontAtlas* fonts, ImFont* font, ImWchar id, int width, int height, float advance_x, ImVec2* offset)
+{
+	return fonts->AddCustomRectFontGlyph(font, id, width, height, advance_x, offset == nullptr ? ImVec2(0, 0) : *offset);
+}
+
+HL_PRIM ImFontAtlasCustomRect* F_NAME(get_custom_rect_by_index)(ImFontAtlas* fonts, int index)
+{
+	return fonts->GetCustomRectByIndex(index);
+}
+
+HL_PRIM void F_NAME(calc_custom_rect_uv)(ImFontAtlas* fonts, ImFontAtlasCustomRect* rect, ImVec2* out_uv_min, ImVec2* out_uv_max)
+{
+	return fonts->CalcCustomRectUV(rect, out_uv_min, out_uv_max);
+}
+
+typedef struct {
+	hl_type* t;
+	ImVec2* offset;
+	ImVec2* size;
+	ImVec4* uv_border; // xy = min, zw = max
+	ImVec4* uv_fill; // xy = min, zw = max
+} vcursordata;
+#define _CURSORDATA _OBJ(_IMVEC2 _IMVEC2 _IMVEC4 _IMVEC4)
+
+HL_PRIM bool F_NAME(get_mouse_cursor_tex_data)(ImFontAtlas* fonts, ImGuiMouseCursor cursor, vcursordata* output)
+{
+	return fonts->GetMouseCursorTexData(cursor, output->offset, output->size, (ImVec2*)output->uv_border, (ImVec2*)output->uv_fill);
 }
 
 HL_PRIM void HL_NAME(push_font)(ImFont *font)
 {
-    ImGui::PushFont( font );
+	ImGui::PushFont( font );
 }
 
 HL_PRIM void HL_NAME(pop_font)()
 {
-    ImGui::PopFont();
+	ImGui::PopFont();
 }
 
 HL_PRIM ImFont* HL_NAME(get_font)()
 {
-    return ImGui::GetFont();
+	return ImGui::GetFont();
 }
 
-
-HL_PRIM void HL_NAME(build_font)()
+HL_PRIM void HL_NAME(imfontconfig_init)(ImFontConfig* cfg)
 {
-    ImGui::GetIO().Fonts->Build();
+	new (cfg)ImFontConfig();
 }
 
-#define _TFONT _ABSTRACT(imfont)
+DEFINE_PRIM(_TFONTATLAS, get_font_atlas, _NO_ARG);
+DEFINE_FPRIM(_TFONT, add_font, _STRUCT);
+DEFINE_FPRIM(_TFONT, add_font_default, _STRUCT);
+DEFINE_FPRIM(_TFONT, add_font_from_file_ttf, _STRING _F32 _STRUCT _ARR);
+DEFINE_FPRIM(_TFONT, add_font_from_memory_ttf, _BYTES _I32 _F32 _STRUCT _ARR);
+// DEFINE_FPRIM(_TFONT, add_font_from_memory_compressed_ttf, _BYTES _I32 _F32 _STRUCT _ARR);
+// DEFINE_FPRIM(_TFONT, add_font_from_memory_compressed_base85_ttf, _BYTES _I32 _F32 _STRUCT _ARR);
+DEFINE_FPRIM(_VOID, clear_input_data, _NO_ARG);
+DEFINE_FPRIM(_VOID, clear_tex_data, _NO_ARG);
+DEFINE_FPRIM(_VOID, clear_fonts, _NO_ARG);
+DEFINE_FPRIM(_VOID, clear, _NO_ARG);
+DEFINE_FPRIM(_BOOL, build, _NO_ARG);
+DEFINE_FPRIM(_VOID, get_tex_data_as_alpha8, _TEXDATA);
+DEFINE_FPRIM(_VOID, get_tex_data_as_rgba32, _TEXDATA);
+DEFINE_FPRIM(_BOOL, is_built, _NO_ARG);
+DEFINE_FPRIM(_VOID, set_tex_id, _IMTEXID);
+// GetGlyphRangesX
+DEFINE_FPRIM(_I32, add_custom_rect_regular, _I32 _I32);
+DEFINE_FPRIM(_I32, add_custom_rect_font_glyph, _TFONT _I16 _I32 _I32 _F32 _IMVEC2);
+DEFINE_FPRIM(_STRUCT, get_custom_rect_by_index, _I32);
+DEFINE_FPRIM(_VOID, calc_custom_rect_uv, _STRUCT _IMVEC2 _IMVEC2);
+DEFINE_FPRIM(_BOOL, get_mouse_cursor_tex_data, _I32 _CURSORDATA);
 
-DEFINE_PRIM(_TFONT, add_font_default, _DYN );
-DEFINE_PRIM(_TFONT, add_font_from_memory_ttf, _BYTES _I32 _F32 _DYN _ARR );
-DEFINE_PRIM(_TFONT, add_font_from_file_ttf, _STRING _F32 _DYN _ARR );
-DEFINE_PRIM(_DYN, get_tex_data_as_rgba32, _NO_ARG);
 DEFINE_PRIM(_VOID, push_font, _TFONT);
 DEFINE_PRIM(_VOID, pop_font, _NO_ARG );
 DEFINE_PRIM(_TFONT, get_font, _NO_ARG);
-DEFINE_PRIM(_VOID, build_font, _NO_ARG );
+DEFINE_PRIM(_VOID, imfontconfig_init, _STRUCT);

--- a/extension/font.cpp
+++ b/extension/font.cpp
@@ -110,7 +110,7 @@ HL_PRIM int F_NAME(add_custom_rect_regular)(ImFontAtlas* fonts, int width, int h
 
 HL_PRIM int F_NAME(add_custom_rect_font_glyph)(ImFontAtlas* fonts, ImFont* font, ImWchar id, int width, int height, float advance_x, vimvec2* offset)
 {
-	return fonts->AddCustomRectFontGlyph(font, id, width, height, advance_x, offset != nullptr ? offset->v : ImVec2(0, 0));
+	return fonts->AddCustomRectFontGlyph(font, id, width, height, advance_x, offset != nullptr ? *offset->v() : ImVec2(0, 0));
 }
 
 HL_PRIM ImFontAtlasCustomRect* F_NAME(get_custom_rect_by_index)(ImFontAtlas* fonts, int index)
@@ -120,7 +120,7 @@ HL_PRIM ImFontAtlasCustomRect* F_NAME(get_custom_rect_by_index)(ImFontAtlas* fon
 
 HL_PRIM void F_NAME(calc_custom_rect_uv)(ImFontAtlas* fonts, ImFontAtlasCustomRect* rect, vimvec2* out_uv_min, vimvec2* out_uv_max)
 {
-	return fonts->CalcCustomRectUV(rect, &out_uv_min->v, &out_uv_max->v);
+	return fonts->CalcCustomRectUV(rect, out_uv_min->v(), out_uv_max->v());
 }
 
 typedef struct {
@@ -134,7 +134,7 @@ typedef struct {
 
 HL_PRIM bool F_NAME(get_mouse_cursor_tex_data)(ImFontAtlas* fonts, ImGuiMouseCursor cursor, vcursordata* output)
 {
-	return fonts->GetMouseCursorTexData(cursor, &output->offset->v, &output->size->v, (&output->uv_border->min), (&output->uv_fill->min));
+	return fonts->GetMouseCursorTexData(cursor, output->offset->v(), output->size->v(), output->uv_border->vmin(), output->uv_fill->vmin());
 }
 
 HL_PRIM void HL_NAME(push_font)(ImFont *font)

--- a/extension/hlimgui.cpp
+++ b/extension/hlimgui.cpp
@@ -13,6 +13,8 @@ typedef struct
 } HeapVertex;
 
 static vclosure* s_render_function = nullptr;
+hl_type* hlt_imvec2;
+hl_type* hlt_imvec4;
 
 void renderDrawLists(ImDrawData* draw_data)
 {
@@ -158,6 +160,16 @@ HL_PRIM void HL_NAME(render)()
 	renderDrawLists(draw_data);
 }
 
+/**
+	Hack: Because we want to allocate ImVec2/4 classes on HL side, we need to hijack the hl_type of those classes somehow.
+	And there's no API to obtain said classes. So we steal them from live instances.
+**/
+HL_PRIM void HL_NAME(initialize)(vimvec2* hl_vec2, vimvec4* hl_vec4) {
+	hlt_imvec2 = hl_vec2->t;
+	hlt_imvec4 = hl_vec4->t;
+}
+
+DEFINE_PRIM(_VOID, initialize, _IMVEC2 _IMVEC4);
 DEFINE_PRIM(_VOID, set_render_callback, _FUN(_VOID, _DYN));
 DEFINE_PRIM(_VOID, add_key_char, _I32);
 DEFINE_PRIM(_VOID, add_key_event, _I32 _BOOL);

--- a/extension/hlimgui.cpp
+++ b/extension/hlimgui.cpp
@@ -102,65 +102,14 @@ void renderDrawLists(ImDrawData* draw_data)
 
 	vdynamic* args[1];
 	args[0] = param;
-	hl_dyn_call(s_render_function, args, 1);
+	if (s_render_function != nullptr) hl_dyn_call(s_render_function, args, 1);
 }
 
-HL_PRIM vdynamic* HL_NAME(initialize)(vclosure* render_fn)
+HL_PRIM void HL_NAME(set_render_callback)(vclosure* render_fn)
 {
-	ImGui::CreateContext();
-	ImGuiIO& io = ImGui::GetIO();
-
-	// set render draw function
+	if (s_render_function != nullptr) hl_remove_root(&s_render_function);
 	s_render_function = render_fn;
-	hl_add_root(&s_render_function);
-
-	// create default font texture buffer
-	io.Fonts->AddFontDefault();
-
-	unsigned char* pixels;
-	int width, height;
-	io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);
-
-	vbyte* buffer = hl_copy_bytes(pixels, width*height*4);
-
-	vdynamic* font_info = (vdynamic*)hl_alloc_dynobj();
-	hl_dyn_setp(font_info, hl_hash_utf8("buffer"), &hlt_bytes, buffer);
-	hl_dyn_seti(font_info, hl_hash_utf8("width"), &hlt_i32, width);
-	hl_dyn_seti(font_info, hl_hash_utf8("height"), &hlt_i32, height);
-	
-	ImVec2 offset, size, uv[4];
-	vdynamic* cursors = nullptr;
-	
-	// Retrieve cursor positioning data from imgui default font and pass it to Heaps
-	// Allows us to display all actual cursors without being restricted by what Heaps supports.
-	for ( int cursor = ImGuiMouseCursor_Arrow; cursor < ImGuiMouseCursor_COUNT; cursor++) {
-		if (io.Fonts->GetMouseCursorTexData(cursor, &offset, &size, &uv[0], &uv[2])) {
-			vdynamic* cur = (vdynamic*)hl_alloc_dynobj();
-			hl_dyn_seti(cur, hl_hash_utf8("x1"), &hlt_i32, (int)(uv[0].x * width));
-			hl_dyn_seti(cur, hl_hash_utf8("y1"), &hlt_i32, (int)(uv[0].y * height));
-			hl_dyn_seti(cur, hl_hash_utf8("x2"), &hlt_i32, (int)(uv[2].x * width));
-			hl_dyn_seti(cur, hl_hash_utf8("y2"), &hlt_i32, (int)(uv[2].y * height));
-			hl_dyn_seti(cur, hl_hash_utf8("w"), &hlt_i32, (int)size.x);
-			hl_dyn_seti(cur, hl_hash_utf8("h"), &hlt_i32, (int)size.y);
-			hl_dyn_seti(cur, hl_hash_utf8("ox"), &hlt_i32, (int)offset.x);
-			hl_dyn_seti(cur, hl_hash_utf8("oy"), &hlt_i32, (int)offset.y);
-			hl_dyn_seti(cur, hl_hash_utf8("c"), &hlt_i32, cursor);
-			
-			hl_dyn_setp(cur, hl_hash_utf8("next"), &hlt_dynobj, cursors);
-			cursors = cur;
-		}
-	}
-	hl_dyn_setp(font_info, hl_hash_utf8("cursors"), &hlt_dynobj, cursors);
-
-	io.Fonts->ClearTexData();
-
-	return font_info;
-}
-
-HL_PRIM void HL_NAME(set_font_texture)(ImTextureID texture_id)
-{
-	ImGuiIO& io = ImGui::GetIO();
-	io.Fonts->SetTexID(texture_id);
+	if (render_fn != nullptr) hl_add_root(&s_render_function);
 }
 
 HL_PRIM void HL_NAME(add_key_char)(int c)
@@ -209,8 +158,7 @@ HL_PRIM void HL_NAME(render)()
 	renderDrawLists(draw_data);
 }
 
-DEFINE_PRIM(_DYN, initialize, _FUN(_VOID, _DYN));
-DEFINE_PRIM(_VOID, set_font_texture, _DYN);
+DEFINE_PRIM(_VOID, set_render_callback, _FUN(_VOID, _DYN));
 DEFINE_PRIM(_VOID, add_key_char, _I32);
 DEFINE_PRIM(_VOID, add_key_event, _I32 _BOOL);
 DEFINE_PRIM(_VOID, set_events, _F32 _F32 _F32 _F32 _BOOL _BOOL);

--- a/extension/imgui_config.h
+++ b/extension/imgui_config.h
@@ -72,13 +72,19 @@
 // #include "../utils.h"
 
 #include <hl.h>
+#include "types.h"
+
 #define IM_VEC2_CLASS_EXTRA                                                 \
         ImVec2(vdynamic* dyn) { x = hl_dyn_getf(dyn, hl_hash_utf8("x")); y = hl_dyn_getf(dyn, hl_hash_utf8("y")); } \
-        operator vdynamic*() const { vdynamic* vec2 = (vdynamic*)hl_alloc_dynobj(); hl_dyn_setf(vec2, hl_hash_utf8("x"), x); hl_dyn_setf(vec2, hl_hash_utf8("y"), y); return vec2; }
+        operator vdynamic*() const { vdynamic* vec2 = (vdynamic*)hl_alloc_dynobj(); hl_dyn_setf(vec2, hl_hash_utf8("x"), x); hl_dyn_setf(vec2, hl_hash_utf8("y"), y); return vec2; }\
+        ImVec2(vimvec2* vec) { x = vec->x; y = vec->y; }\
+        operator vimvec2*() const { vimvec2* vec = (vimvec2*)hl_alloc_obj(hlt_imvec2); vec->x = x; vec->y = y; return vec; }
 
 #define IM_VEC4_CLASS_EXTRA                                                 \
         ImVec4(vdynamic* dyn) { x = hl_dyn_getf(dyn, hl_hash_utf8("x")); y = hl_dyn_getf(dyn, hl_hash_utf8("y")); z = hl_dyn_getf(dyn, hl_hash_utf8("z")); w = hl_dyn_getf(dyn, hl_hash_utf8("w")); }     \
-        operator vdynamic*() const { vdynamic* vec4 = (vdynamic*)hl_alloc_dynobj(); hl_dyn_setf(vec4, hl_hash_utf8("x"), x); hl_dyn_setf(vec4, hl_hash_utf8("y"), y); hl_dyn_setf(vec4, hl_hash_utf8("z"), z); hl_dyn_setf(vec4, hl_hash_utf8("w"), w); return vec4; }
+        operator vdynamic*() const { vdynamic* vec4 = (vdynamic*)hl_alloc_dynobj(); hl_dyn_setf(vec4, hl_hash_utf8("x"), x); hl_dyn_setf(vec4, hl_hash_utf8("y"), y); hl_dyn_setf(vec4, hl_hash_utf8("z"), z); hl_dyn_setf(vec4, hl_hash_utf8("w"), w); return vec4; }\
+        ImVec4(vimvec4* vec) { x = vec->x; y = vec->y; z = vec->z; w = vec->w; }\
+        operator vimvec4*() const { vimvec4* vec = (vimvec4*)hl_alloc_obj(hlt_imvec4); vec->x = x; vec->y = y; vec->z = z; vec->w = w; return vec; }
 
 //---- Use 32-bit vertex indices (default is 16-bit) is one way to allow large meshes with more than 64K vertices.
 // Your renderer backend will need to support it (most example renderer backends support both 16/32-bit indices).

--- a/extension/types.h
+++ b/extension/types.h
@@ -1,22 +1,22 @@
 #pragma once
 
 #include <hl.h>
-typedef struct {
-	hl_type* t;
-	union {
-		ImVec2 v;
-		struct { float x; float y; };
-	};
-} vimvec2;
-
-typedef struct {
-	hl_type* t;
-	union {
-		ImVec4 v;
-		struct { ImVec2 min; ImVec2 max; };
-		struct { float x; float y; float z; float w; };
-	};
-} vimvec4;
+typedef struct ImVec2 ImVec2;
+typedef struct ImVec4 ImVec4;
 
 extern hl_type* hlt_imvec2;
 extern hl_type* hlt_imvec4;
+
+typedef struct HLT_ImVec2 {
+	hl_type* t;
+	float x, y;
+	inline ImVec2* v() const { return (ImVec2*)&x; };
+} vimvec2;
+
+typedef struct HLT_ImVec4 {
+	hl_type* t;
+	float x, y, z, w;
+	inline ImVec4* v() const { return (ImVec4*)&x; };
+	inline ImVec2* vmin() const { return (ImVec2*)&x; };
+	inline ImVec2* vmax() const { return (ImVec2*)&z; };
+} vimvec4;

--- a/extension/types.h
+++ b/extension/types.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <hl.h>
+typedef struct {
+	hl_type* t;
+	union {
+		ImVec2 v;
+		struct { float x; float y; };
+	};
+} vimvec2;
+
+typedef struct {
+	hl_type* t;
+	union {
+		ImVec4 v;
+		struct { ImVec2 min; ImVec2 max; };
+		struct { float x; float y; float z; float w; };
+	};
+} vimvec4;
+
+extern hl_type* hlt_imvec2;
+extern hl_type* hlt_imvec4;

--- a/extension/utils.cpp
+++ b/extension/utils.cpp
@@ -184,28 +184,6 @@ void setStructArrayImVec4(vdynamic* dyn, const char* name, const ImVec4* values,
 	hl_dyn_setp(dyn, hl_hash_utf8(name), &hlt_array, array);
 }
 
-void getImGuiFontConfigFromHL(ImFontConfig *imgui_font_config, vdynamic* config)
-{
-
-	getStructInt(config, "OversampleH", imgui_font_config->OversampleH);
-	getStructInt(config, "OversampleV", imgui_font_config->OversampleV);
-	getStructBool(config, "PixelSnapH", imgui_font_config->PixelSnapH);
-	getStructImVec2(config, "GlyphExtraSpacing", imgui_font_config->GlyphExtraSpacing);
-	getStructImVec2(config, "GlyphOffset", imgui_font_config->GlyphOffset);
-
-	getStructFloat(config, "GlyphMinAdvanceX", imgui_font_config->GlyphMinAdvanceX);
-	getStructFloat(config, "GlyphMaxAdvanceX", imgui_font_config->GlyphMaxAdvanceX);
-	getStructBool(config, "MergeMode", imgui_font_config->MergeMode);
-	getStructInt(config, "FontBuilderFlags", (int&)imgui_font_config->FontBuilderFlags);
-	getStructFloat(config, "RasterizerMultiply", imgui_font_config->RasterizerMultiply);
-	getStructInt(config, "EllipsisChar", (int&)imgui_font_config->EllipsisChar);
-
-	varray* ranges = (varray*)hl_dyn_getp(config, hl_hash_utf8("GlyphRanges"), &hlt_array);
-	ImWchar *glyph_ranges = ranges != nullptr ? hl_aptr(ranges,ImWchar) : nullptr;
-
-	imgui_font_config->GlyphRanges = glyph_ranges;
-}
-
 // ImVec2 getImVec2(vdynamic* vec2, const ImVec2& default_value)
 // {
 // 	ImVec2 result = default_value;

--- a/extension/utils.h
+++ b/extension/utils.h
@@ -1,14 +1,15 @@
 #pragma once
 
 #define HL_NAME(n) hlimgui_##n
-#define _IMVEC2 _STRUCT
-#define _IMVEC4 _STRUCT
+#define _IMVEC2 _OBJ(_F32 _F32)
+#define _IMVEC4 _OBJ(_F32 _F32 _F32 _F32)
 #define _IMTEXID _DYN
 
 #include <string>
 #include <hl.h>
 #include <vector>
 #include "lib/imgui/imgui.h"
+#include "types.h"
 
 #define convertString(st) st != nullptr ? unicodeToUTF8(st).c_str() : NULL
 #define convertStringNullAsEmpty(st) st != nullptr ? unicodeToUTF8(st).c_str() : ""
@@ -27,7 +28,7 @@
 // DEFINE_PRIM(_I32,get_prop_name,_NO_ARG)
 // DEFINE_PRIM(_VOID,set_prop_name,_REF(_I32))
 #define DEFINE_PRIM_PROP(t,name,args) DEFINE_PRIM(t,get_##name,_NO_ARG)\
-    DEFINE_PRIM(_VOID,set_##name,args)
+	DEFINE_PRIM(_VOID,set_##name,args)
 
 void convertColor(ImU32 color, float& r, float& g, float& b, float& a);
 int unicodeSizeInUTF8(vstring* hl_string);

--- a/extension/utils.h
+++ b/extension/utils.h
@@ -15,6 +15,7 @@
 #define convertStringNullAsEmpty(st) st != nullptr ? unicodeToUTF8(st).c_str() : ""
 #define convertPtr(ptr,default_value) ptr != nullptr ? *ptr : default_value
 #define convertArray(arr,type) arr != nullptr ? hl_aptr(arr,type) : nullptr
+#define convertVec(ptr,default_value) ptr != nullptr ? ptr : default_value
 
 #ifdef __APPLE__
 #define throw_error(err) hl_throw(hl_alloc_strbytes((const uchar*)(USTR(err))))

--- a/extension/utils.h
+++ b/extension/utils.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #define HL_NAME(n) hlimgui_##n
+#define _IMVEC2 _STRUCT
+#define _IMVEC4 _STRUCT
+#define _IMTEXID _DYN
 
 #include <string>
 #include <hl.h>
@@ -10,6 +13,7 @@
 #define convertString(st) st != nullptr ? unicodeToUTF8(st).c_str() : NULL
 #define convertStringNullAsEmpty(st) st != nullptr ? unicodeToUTF8(st).c_str() : ""
 #define convertPtr(ptr,default_value) ptr != nullptr ? *ptr : default_value
+#define convertArray(arr,type) arr != nullptr ? hl_aptr(arr,type) : nullptr
 
 #ifdef __APPLE__
 #define throw_error(err) hl_throw(hl_alloc_strbytes((const uchar*)(USTR(err))))
@@ -29,8 +33,6 @@ void convertColor(ImU32 color, float& r, float& g, float& b, float& a);
 int unicodeSizeInUTF8(vstring* hl_string);
 void unicodeToUTF8Buffer(vstring* hl_string, char* out);
 std::string unicodeToUTF8(vstring* hl_string);
-
-void getImGuiFontConfigFromHL(ImFontConfig *imgui_font_config, vdynamic* config);
 
 // Replaced by imconfig.h extra converters
 inline ImVec2 getImVec2(vdynamic* vec2, const ImVec2& default_value = ImVec2(0, 0)) { return vec2 == nullptr ? default_value : vec2; }

--- a/imgui/ImGui.hx
+++ b/imgui/ImGui.hx
@@ -613,6 +613,49 @@ typedef ImTextureID = Dynamic;
 typedef ImU32 = Int;
 typedef ImGuiID = Int;
 
+/** The raw memory ImVec2 **/
+@:struct @:structInit class ImVec2S {
+	public var x: Single;
+	public var y: Single;
+	
+	public static inline function get(x: Single = 0, y: Single = 0): ImVec2S { return { x: x, y: y }; };
+	// TODO: Math operations
+}
+
+/** The raw memory ImVec2 **/
+@:struct @:structInit class ImVec4S {
+	public var x: Single;
+	public var y: Single;
+	public var z: Single;
+	public var w: Single;
+	
+	public static inline function get(x: Single = 0, y: Single = 0, z: Single = 0, w: Single = 0): ImVec4S { return { x: x, y: y, z: z, w: w }; }
+	public static inline function getColor(colWAlpha: Int): ImVec4S {
+		return {
+			x: ((colWAlpha      ) & 0xff) / 0xff,
+			y: ((colWAlpha >> 8 ) & 0xff) / 0xff,
+			z: ((colWAlpha >> 16) & 0xff) / 0xff,
+			w: ((colWAlpha >> 24) & 0xff) / 0xff
+		};
+	}
+	public static inline function getColorRGB(col: Int, alpha: Float = 1.0): ImVec4S {
+		return {
+			x: ((col      ) & 0xff) / 0xff,
+			y: ((col >> 8 ) & 0xff) / 0xff,
+			z: ((col >> 16) & 0xff) / 0xff,
+			w: alpha
+		};
+	}
+	
+	public inline function toColor():Int {
+		return ((Std.int(x * 0xff) & 0xff)      ) +
+		       ((Std.int(y * 0xff) & 0xff) << 8 ) +
+		       ((Std.int(z * 0xff) & 0xff) << 16) +
+		       ((Std.int(w * 0xff) & 0xff) << 24);
+	}
+	// TODO: Math opeartion
+}
+
 typedef ImVec2 = {
 	x : Single,
 	y : Single

--- a/imgui/ImGui.hx
+++ b/imgui/ImGui.hx
@@ -569,7 +569,7 @@ abstract ExtDynamic<T>(Dynamic) from T to T {
     var RoundCornersLeft            = RoundCornersBottomLeft | RoundCornersTopLeft;
     var RoundCornersRight           = RoundCornersBottomRight | RoundCornersTopRight;
     var RoundCornersAll             = RoundCornersTopLeft | RoundCornersTopRight | RoundCornersBottomLeft | RoundCornersBottomRight;
-    var RoundCornersDefault_        = RoundCornersAll; // Default to ALL corners if none of the _RoundCornersXX flags are specified.
+    var RoundCornersDefault_        = (1 << 4 | 1 << 5 | 1 << 6 | 1 << 7); // Default to ALL corners if none of the _RoundCornersXX flags are specified.
     var RoundCornersMask_           = RoundCornersAll | RoundCornersNone;
 }
 

--- a/imgui/ImGui.hx
+++ b/imgui/ImGui.hx
@@ -852,31 +852,39 @@ class ImGuiInputTextCallbackData
 @:hlNative("hlimgui")
 abstract ImDrawList(ImDrawListPtr) from ImDrawListPtr to ImDrawListPtr
 {
-	public function new(ptr: ImDrawListPtr) { this = ptr; }
+	public inline function new(ptr: ImDrawListPtr) { this = ptr; }
 
-	public function addLine( p1: ImVec2, p2: ImVec2, col: ImU32, thickness: Single = 1.0 ) { drawlist_add_line( this, p1, p2, col, thickness ); }
-	public function addRect( pMin: ImVec2, pMax: ImVec2, col: ImU32, rounding: Single = 0.0, roundingCorners: ImDrawFlags = ImDrawFlags.None, thickness: Single = 1.0 ) { drawlist_add_rect( this, pMin, pMax, col, rounding, roundingCorners, thickness ); }
-	public function addRectFilled( pMin: ImVec2, pMax: ImVec2, col: ImU32, rounding: Single = 0.0, roundingCorners: ImDrawFlags = ImDrawFlags.None ) { drawlist_add_rect_filled( this, pMin, pMax, col, rounding, roundingCorners); }
-	public function addRectFilledMultiColor( pMin: ExtDynamic<ImVec2>, pMax: ExtDynamic<ImVec2>, col_upr_left: ImU32, col_upr_right: ImU32, col_bot_right: ImU32, col_bot_left: ImU32 ) { drawlist_add_rect_filled_multicolor( this, pMin, pMax, col_upr_left, col_upr_right, col_bot_right, col_bot_left ); }
-	public function addQuad( p1: ExtDynamic<ImVec2>, p2: ExtDynamic<ImVec2>, p3: ExtDynamic<ImVec2>, p4: ExtDynamic<ImVec2>, col: ImU32, thickness: Single = 1.0 ) { drawlist_add_quad(this, p1, p2, p3, p4, col, thickness ); }
-	public function addQuadFilled( p1: ExtDynamic<ImVec2>, p2: ExtDynamic<ImVec2>, p3: ExtDynamic<ImVec2>, p4: ExtDynamic<ImVec2>, col: ImU32 ) { drawlist_add_quad_filled( this, p1, p2, p3, p4, col ); }
-	public function addTriangle( p1: ExtDynamic<ImVec2>, p2: ExtDynamic<ImVec2>, p3: ExtDynamic<ImVec2>, col: ImU32, thickness: Single = 1.0 ) { drawlist_add_triangle(this, p1, p2, p3, col, thickness ); }
-	public function addTriangleFilled( p1: ExtDynamic<ImVec2>, p2: ExtDynamic<ImVec2>, p3: ExtDynamic<ImVec2>, col: ImU32 ) { drawlist_add_triangle_filled(this, p1, p2, p3, col ); }
-	public function addCircle( center: ExtDynamic<ImVec2>, radius: Single, col: ImU32, num_segments: Int = 0, thickness: Single = 1.0 ) { drawlist_add_circle( this, center, radius, col, num_segments, thickness ); }
-	public function addCircleFilled( center: ExtDynamic<ImVec2>, radius: Single, col: ImU32, num_segments: Int = 0) { drawlist_add_circle_filled(this, center, radius, col, num_segments ); }
-	public function addNgon( center: ExtDynamic<ImVec2>, radius: Single, col: ImU32, num_segments: Int, thickness: Single = 1.0 ) { drawlist_add_ngon(this, center, radius, col, num_segments, thickness ); }
-	public function addNgonFilled( center: ExtDynamic<ImVec2>, radius: Single, col: ImU32, num_segments: Int = 0) { drawlist_add_ngon_filled(this, center, radius, col, num_segments ); }
-	//public function addPolyLine( points: hl.NativeArray<ImVec2>, col: ImU32, closed: Bool, thickness: Single = 1.0 ) { drawlist_add_poly_line(this, points, col, closed, thickness ); }
-	//public function addConvexPolyFilled( points: hl.NativeArray<ExtDynamic<ImVec2>>, col: ImU32 ) { drawlist_add_convex_poly_filled(this, points, col ); }
-	public function addBezierCurve( p1: ExtDynamic<ImVec2>, p2: ExtDynamic<ImVec2>, p3: ExtDynamic<ImVec2>, p4: ExtDynamic<ImVec2>, col: ImU32, thickness: Single = 1.0, num_segments: Int = 0 ) { drawlist_add_bezier_curve(this, p1, p2, p3, p4, col, thickness, num_segments ); }
+	public inline function pushClipRect(clipRectMin: ImVec2, clipRectMax: ImVec2, intersectWithCurrentClipRect: Bool = false) { drawlist_push_clip_rect(this, clipRectMin, clipRectMax, intersectWithCurrentClipRect); }
+	public inline function pushClipRectFullScreen() { drawlist_push_clip_rect_full_screen(this); }
+	public inline function popClipRect() { drawlist_pop_clip_rect(this); }
+	public inline function pushTextureId(textureId: ImTextureID) { drawlist_push_texture_id(this, textureId); }
+	public inline function popTextureId() { drawlist_pop_texture_id(this); }
+	public inline function getClipRectMin(): ImVec2 { return drawlist_get_clip_rect_min(this); }
+	public inline function getClipRectMax(): ImVec2 { return drawlist_get_clip_rect_max(this); }
+
+	public inline function addLine( p1: ImVec2, p2: ImVec2, col: ImU32, thickness: Single = 1.0 ) { drawlist_add_line( this, p1, p2, col, thickness ); }
+	public inline function addRect( pMin: ImVec2, pMax: ImVec2, col: ImU32, rounding: Single = 0.0, roundingCorners: ImDrawFlags = ImDrawFlags.None, thickness: Single = 1.0 ) { drawlist_add_rect( this, pMin, pMax, col, rounding, roundingCorners, thickness ); }
+	public inline function addRectFilled( pMin: ImVec2, pMax: ImVec2, col: ImU32, rounding: Single = 0.0, roundingCorners: ImDrawFlags = ImDrawFlags.None ) { drawlist_add_rect_filled( this, pMin, pMax, col, rounding, roundingCorners); }
+	public inline function addRectFilledMultiColor( pMin: ExtDynamic<ImVec2>, pMax: ExtDynamic<ImVec2>, col_upr_left: ImU32, col_upr_right: ImU32, col_bot_right: ImU32, col_bot_left: ImU32 ) { drawlist_add_rect_filled_multicolor( this, pMin, pMax, col_upr_left, col_upr_right, col_bot_right, col_bot_left ); }
+	public inline function addQuad( p1: ExtDynamic<ImVec2>, p2: ExtDynamic<ImVec2>, p3: ExtDynamic<ImVec2>, p4: ExtDynamic<ImVec2>, col: ImU32, thickness: Single = 1.0 ) { drawlist_add_quad(this, p1, p2, p3, p4, col, thickness ); }
+	public inline function addQuadFilled( p1: ExtDynamic<ImVec2>, p2: ExtDynamic<ImVec2>, p3: ExtDynamic<ImVec2>, p4: ExtDynamic<ImVec2>, col: ImU32 ) { drawlist_add_quad_filled( this, p1, p2, p3, p4, col ); }
+	public inline function addTriangle( p1: ExtDynamic<ImVec2>, p2: ExtDynamic<ImVec2>, p3: ExtDynamic<ImVec2>, col: ImU32, thickness: Single = 1.0 ) { drawlist_add_triangle(this, p1, p2, p3, col, thickness ); }
+	public inline function addTriangleFilled( p1: ExtDynamic<ImVec2>, p2: ExtDynamic<ImVec2>, p3: ExtDynamic<ImVec2>, col: ImU32 ) { drawlist_add_triangle_filled(this, p1, p2, p3, col ); }
+	public inline function addCircle( center: ExtDynamic<ImVec2>, radius: Single, col: ImU32, num_segments: Int = 0, thickness: Single = 1.0 ) { drawlist_add_circle( this, center, radius, col, num_segments, thickness ); }
+	public inline function addCircleFilled( center: ExtDynamic<ImVec2>, radius: Single, col: ImU32, num_segments: Int = 0) { drawlist_add_circle_filled(this, center, radius, col, num_segments ); }
+	public inline function addNgon( center: ExtDynamic<ImVec2>, radius: Single, col: ImU32, num_segments: Int, thickness: Single = 1.0 ) { drawlist_add_ngon(this, center, radius, col, num_segments, thickness ); }
+	public inline function addNgonFilled( center: ExtDynamic<ImVec2>, radius: Single, col: ImU32, num_segments: Int = 0) { drawlist_add_ngon_filled(this, center, radius, col, num_segments ); }
+	public inline function addPolyLine( points: hl.NativeArray<ImVec2>, col: ImU32, closed: Bool, thickness: Single = 1.0 ) { drawlist_add_poly_line(this, points, col, closed, thickness ); }
+	public inline function addConvexPolyFilled( points: hl.NativeArray<ExtDynamic<ImVec2>>, col: ImU32 ) { drawlist_add_convex_poly_filled(this, points, col ); }
+	public inline function addBezierCurve( p1: ExtDynamic<ImVec2>, p2: ExtDynamic<ImVec2>, p3: ExtDynamic<ImVec2>, p4: ExtDynamic<ImVec2>, col: ImU32, thickness: Single = 1.0, num_segments: Int = 0 ) { drawlist_add_bezier_curve(this, p1, p2, p3, p4, col, thickness, num_segments ); }
 	//
-	public function addText( pos: ImVec2, col: ImU32, text: String ) { drawlist_add_text(this, pos, col, text); }
-	public function addText2( font: ImFont, fontSize: Single, pos: ImVec2, col: ImU32, text: String, wrapWidth: Single = 0.0, ?cpuFineClipRect: ImVec4 ) { drawlist_add_text2(this, font==null?null:(@:privateAccess font.ptr), fontSize, pos, col, text, wrapWidth, cpuFineClipRect); }
+	public inline function addText( pos: ImVec2, col: ImU32, text: String ) { drawlist_add_text(this, pos, col, text); }
+	public inline function addText2( font: ImFont, fontSize: Single, pos: ImVec2, col: ImU32, text: String, wrapWidth: Single = 0.0, ?cpuFineClipRect: ImVec4 ) { drawlist_add_text2(this, font==null?null:(@:privateAccess font), fontSize, pos, col, text, wrapWidth, cpuFineClipRect); }
 
-	public function addImage( userTextureId: ImTextureID, pMin: ImVec2, pMax: ImVec2, ?uvMin: ImVec2, ?uvMax: ImVec2, col: Int = 0xffffffff ) { drawlist_add_image(this, userTextureId, pMin, pMax, uvMin, uvMax, col); }
-	public function addImageQuad( userTextureId: ImTextureID, p1: ImVec2, p2: ImVec2, p3: ImVec2, p4: ImVec2, ?uv1: ImVec2, ?uv2: ImVec2, ?uv3: ImVec2, ?uv4: ImVec2, col: Int = 0xffffffff ) { drawlist_add_image_quad(this, userTextureId, p1, p2, p3, p4, uv1, uv2, uv3, uv4, col); }
+	public inline function addImage( userTextureId: ImTextureID, pMin: ImVec2, pMax: ImVec2, ?uvMin: ImVec2, ?uvMax: ImVec2, col: Int = 0xffffffff ) { drawlist_add_image(this, userTextureId, pMin, pMax, uvMin, uvMax, col); }
+	public inline function addImageQuad( userTextureId: ImTextureID, p1: ImVec2, p2: ImVec2, p3: ImVec2, p4: ImVec2, ?uv1: ImVec2, ?uv2: ImVec2, ?uv3: ImVec2, ?uv4: ImVec2, col: Int = 0xffffffff ) { drawlist_add_image_quad(this, userTextureId, p1, p2, p3, p4, uv1, uv2, uv3, uv4, col); }
 	// Due to Haxe limitation on defualt parameters being "constant" and enum abstract values that rely on previous enum abstract value (A | B) are not "constant" - hack with -1
-	public function addImageRounded( userTextureId: ImTextureID, pMin: ImVec2, pMax: ImVec2, ?uvMin: ImVec2, ?uvMax: ImVec2, col: Int, rounding: Single, roundingCorners: ImDrawFlags = -1 ) { drawlist_add_image_rounded(this, userTextureId, pMin, pMax, uvMin, uvMax, col, rounding, roundingCorners == -1 ? ImDrawFlags.RoundCornersDefault_ : roundingCorners); }
+	public inline function addImageRounded( userTextureId: ImTextureID, pMin: ImVec2, pMax: ImVec2, ?uvMin: ImVec2, ?uvMax: ImVec2, col: Int, rounding: Single, roundingCorners: ImDrawFlags = -1 ) { drawlist_add_image_rounded(this, userTextureId, pMin, pMax, uvMin, uvMax, col, rounding, roundingCorners == -1 ? ImDrawFlags.RoundCornersDefault_ : roundingCorners); }
 
 	#if heaps
 	// Helper methods for Heaps: Use Tile instead of Texture to pass image segments easily.
@@ -909,6 +917,14 @@ abstract ImDrawList(ImDrawListPtr) from ImDrawListPtr to ImDrawListPtr
 	}
 	#end
 
+	static function drawlist_push_clip_rect( drawlist: ImDrawListPtr, clip_rect_min: ExtDynamic<ImVec2>, clip_rect_max: ExtDynamic<ImVec2>, intersect_with_current_clip_rect: Bool ) {}
+	static function drawlist_push_clip_rect_full_screen( drawlist: ImDrawListPtr ) {}
+	static function drawlist_pop_clip_rect( drawlist: ImDrawListPtr ) {}
+	static function drawlist_push_texture_id( drawlist: ImDrawListPtr, texture_id: ImTextureID ) {}
+	static function drawlist_pop_texture_id( drawlist: ImDrawListPtr ) {}
+	static function drawlist_get_clip_rect_min( drawlist: ImDrawListPtr ): ExtDynamic<ImVec2> { return null; }
+	static function drawlist_get_clip_rect_max( drawlist: ImDrawListPtr ): ExtDynamic<ImVec2> { return null; }
+	
 	static function drawlist_add_line( drawlist: ImDrawListPtr, p1: ExtDynamic<ImVec2>, p2: ExtDynamic<ImVec2>, col: ImU32, thickness: Single ) {}
 	static function drawlist_add_rect( drawlist: ImDrawListPtr, pMin: ExtDynamic<ImVec2>, pMax: ExtDynamic<ImVec2>, col: ImU32, rounding: Single, roundingCorners: ImDrawFlags, thickness ) {}
 	static function drawlist_add_rect_filled( drawlist: ImDrawListPtr, pMin: ExtDynamic<ImVec2>, pMax: ExtDynamic<ImVec2>, col: ImU32, rounding: Single, roundingCorners: ImDrawFlags ) {}

--- a/imgui/ImGuiDrawable.hx
+++ b/imgui/ImGuiDrawable.hx
@@ -29,6 +29,7 @@ class ImGuiDrawableBuffers {
 			return;
 		}
 		
+		ImGui.provideTypes();
 		ImGui.createContext();
 		ImGui.setRenderCallback(renderDrawListsFromExternal);
 		

--- a/imgui/ImGuiDrawable.hx
+++ b/imgui/ImGuiDrawable.hx
@@ -1,19 +1,11 @@
 package imgui;
 
+import imgui.types.ImFontAtlas;
 #if heaps
 
 import h3d.mat.Texture;
 import imgui.ImGui;
 import hxd.Key;
-
-private typedef CursorInfo = { 
-	next: CursorInfo,
-	c: ImGuiMouseCursor,
-	x1: Int, y1: Int,
-	x2: Int, y2: Int,
-	w: Int, h: Int,
-	ox: Int, oy: Int
-}
 
 class ImGuiDrawableBuffers {
 
@@ -36,8 +28,15 @@ class ImGuiDrawableBuffers {
 		if (this.initialized) {
 			return;
 		}
-
-		var font_info:{buffer:hl.Bytes, width:Int, height:Int, cursors: CursorInfo } = ImGui.initialize(renderDrawListsFromExternal);
+		
+		ImGui.createContext();
+		ImGui.setRenderCallback(renderDrawListsFromExternal);
+		
+		var fonts = ImGui.getFontAtlas();
+		var font_info = new ImFontTexData();
+		fonts.addFontDefault();
+		fonts.getTexDataAsRGBA32(font_info);
+		fonts.clearTexData();
 
 		// create font texture
 		var texture_size = font_info.width * font_info.height * 4;
@@ -47,30 +46,37 @@ class ImGuiDrawableBuffers {
 			hxd.PixelFormat.RGBA
 		);
 		font_texture = Texture.fromPixels(font_pixels);
-		ImGui.setFontTexture(font_texture);
+		fonts.setTexId(font_texture);
 
 		#if hlimgui_cursor
-		var cur = font_info.cursors;
-		while (cur != null) {
-			// Assemble the cursor pixel data
-			var cursor_bitmap = new hxd.BitmapData(cur.w+2, cur.h+2);
-			
-			// Mix the fill and outline data same way ImGui would do it
-			for (y in 0...cur.h) for (x in 0...cur.w) {
-				// Outline
-				if ((font_pixels.getPixel(x+cur.x2, y+cur.y2)&0xff000000) != 0)
-				{
-					cursor_bitmap.setPixel(x, y, 0xff000000);
-					// Shadow
-					cursor_bitmap.setPixel(x+1, y+1, 0x30000000);
-					cursor_bitmap.setPixel(x+2, y+2, 0x30000000);
-					
+		var cur = new ImCursorData();
+		for (i in 0...ImGuiMouseCursor.COUNT) {
+			if (fonts.getMouseCursorTexData(i, cur)) {
+				var width = Std.int(cur.size.x);
+				var height = Std.int(cur.size.y);
+				var fillX = Std.int(cur.uvFill.x * font_pixels.width);
+				var fillY = Std.int(cur.uvFill.y * font_pixels.height);
+				var borderX = Std.int(cur.uvBorder.x * font_pixels.width);
+				var borderY = Std.int(cur.uvBorder.y * font_pixels.height);
+				var cursorBitmap = new hxd.BitmapData(width+2, height);
+				for (y in 0...height) for (x in 0...width) {
+					// 4. Draw `uvBorder` with fill color
+					if ((font_pixels.getPixel(x + borderX, y + borderY) & 0xff000000) != 0) {
+						cursorBitmap.setPixel(x, y, 0xffffffff);
+					} else if ((font_pixels.getPixel(x + fillX, y + fillY) & 0xff000000) != 0) {
+						// 3. Draw `uvFill` with border color
+						cursorBitmap.setPixel(x,y, 0xff000000);
+						// 1. Draw `uvFill` offset by [1,0] with shadow color
+						if (cursorBitmap.getPixel(x + 1, y) == 0x30000000)
+							cursorBitmap.setPixel(x + 1, y, 0x57000000); // In case previous pixel was casting shadow - do rough shadow blending.
+						else
+							cursorBitmap.setPixel(x + 1, y, 0x30000000);
+						// 2. Draw `uvFill` offset by [2,0] with shadow color
+						cursorBitmap.setPixel(x + 2, y, 0x30000000);
+					}
 				}
-				// Fill
-				else if ((font_pixels.getPixel(x+cur.x1, y+cur.y1)&0xff000000) != 0) cursor_bitmap.setPixel(x, y, 0xffffffff);
+				cursor_map[i] = hxd.Cursor.Custom(new hxd.Cursor.CustomCursor([cursorBitmap], 0, Std.int(cur.offset.x), Std.int(cur.offset.y)));
 			}
-			cursor_map[cur.c] = hxd.Cursor.Custom(new hxd.Cursor.CustomCursor([cursor_bitmap], 0, cur.ox, cur.oy));
-			cur = cur.next;
 		}
 		#end
 

--- a/imgui/ImGuiUtils.hx
+++ b/imgui/ImGuiUtils.hx
@@ -1,0 +1,39 @@
+package imgui;
+
+import imgui.ImGui;
+
+/**
+	Helper with pre-allocated generic ImGui types to reduce allocation count.
+	
+	Those are expected to be fire-and-forget type and should be available for reuse right after a function call.
+**/
+class ImTypeCache {
+	// TODO: Make it a pool with newFrame() resets.
+	
+	static inline var MAX_SLOTS = 10;
+	static var vec2Slot: Int = 0;
+	static var vec4Slot: Int = 0;
+	
+	/**
+		Retreive a preallocated ImVec2 and set its values to `x` and `y`.
+	**/
+	public static inline function vec2(x: Single, y: Single) {
+		var v = imVec2[vec2Slot++];
+		if (vec2Slot == MAX_SLOTS) vec2Slot = 0;
+		return v.set(x, y);
+	}
+	
+	/**
+		Retreive a preallocated ImVec4 and set its values to `x`, `y`, `z` and `w`.
+	**/
+	public static inline function vec4(x: Single, y: Single, z: Single, w: Single) {
+		var v = imVec4[vec4Slot++];
+		if (vec4Slot == MAX_SLOTS) vec4Slot = 0;
+		return v.set(x, y, z, w);
+	}
+
+	public static var imVec2: Array<ImVec2S> = [for (i in 0...MAX_SLOTS) ({ x: 0, y: 0 })];
+	
+	public static var imVec4: Array<ImVec4S> = [for (i in 0...MAX_SLOTS) ({ x: 0, y: 0, z: 0, w: 0 })];
+
+}

--- a/imgui/types/ImDrawList.hx
+++ b/imgui/types/ImDrawList.hx
@@ -1,0 +1,104 @@
+package imgui.types;
+
+import imgui.ImGuiUtils;
+import imgui.ImGui;
+import imgui.types.Pointers;
+
+@:hlNative("hlimgui", "drawlist_")
+abstract ImDrawList(ImDrawListPtr) from ImDrawListPtr to ImDrawListPtr
+{
+	public inline function new(ptr: ImDrawListPtr) { this = ptr; }
+  
+  // TODO: Migrate to ImVec2S/ImVec4S
+
+	public inline function pushClipRect(clipRectMin: ImVec2, clipRectMax: ImVec2, intersectWithCurrentClipRect: Bool = false) { push_clip_rect(clipRectMin, clipRectMax, intersectWithCurrentClipRect); }
+	public function pushClipRectFullScreen() {}
+	public function popClipRect() {}
+	public function pushTextureId(textureId: ImTextureID) {}
+	public function popTextureId() {}
+	public inline function getClipRectMin(): ImVec2 { return get_clip_rect_min(); }
+	public inline function getClipRectMax(): ImVec2 { return get_clip_rect_max(); }
+
+	public inline function addLine( p1: ImVec2, p2: ImVec2, col: ImU32, thickness: Single = 1.0 ) { add_line( this, p1, p2, col, thickness ); }
+	public inline function addRect( pMin: ImVec2, pMax: ImVec2, col: ImU32, rounding: Single = 0.0, roundingCorners: ImDrawFlags = ImDrawFlags.None, thickness: Single = 1.0 ) { add_rect( this, pMin, pMax, col, rounding, roundingCorners, thickness ); }
+	public inline function addRectFilled( pMin: ImVec2, pMax: ImVec2, col: ImU32, rounding: Single = 0.0, roundingCorners: ImDrawFlags = ImDrawFlags.None ) { add_rect_filled( this, pMin, pMax, col, rounding, roundingCorners); }
+	public inline function addRectFilledMultiColor( pMin: ImVec2, pMax: ImVec2, col_upr_left: ImU32, col_upr_right: ImU32, col_bot_right: ImU32, col_bot_left: ImU32 ) { add_rect_filled_multicolor( this, pMin, pMax, col_upr_left, col_upr_right, col_bot_right, col_bot_left ); }
+	public inline function addQuad( p1: ImVec2, p2: ImVec2, p3: ImVec2, p4: ImVec2, col: ImU32, thickness: Single = 1.0 ) { add_quad(this, p1, p2, p3, p4, col, thickness ); }
+	public inline function addQuadFilled( p1: ImVec2, p2: ImVec2, p3: ImVec2, p4: ImVec2, col: ImU32 ) { add_quad_filled( this, p1, p2, p3, p4, col ); }
+	public inline function addTriangle( p1: ImVec2, p2: ImVec2, p3: ImVec2, col: ImU32, thickness: Single = 1.0 ) { add_triangle(this, p1, p2, p3, col, thickness ); }
+	public inline function addTriangleFilled( p1: ImVec2, p2: ImVec2, p3: ImVec2, col: ImU32 ) { add_triangle_filled(this, p1, p2, p3, col ); }
+	public inline function addCircle( center: ImVec2, radius: Single, col: ImU32, num_segments: Int = 0, thickness: Single = 1.0 ) { add_circle( this, center, radius, col, num_segments, thickness ); }
+	public inline function addCircleFilled( center: ImVec2, radius: Single, col: ImU32, num_segments: Int = 0) { add_circle_filled(this, center, radius, col, num_segments ); }
+	public inline function addNgon( center: ImVec2, radius: Single, col: ImU32, num_segments: Int, thickness: Single = 1.0 ) { add_ngon(this, center, radius, col, num_segments, thickness ); }
+	public inline function addNgonFilled( center: ImVec2, radius: Single, col: ImU32, num_segments: Int = 0) { add_ngon_filled(this, center, radius, col, num_segments ); }
+	public inline function addPolyLine( points: hl.NativeArray<ImVec2>, col: ImU32, closed: Bool, thickness: Single = 1.0 ) { add_poly_line(this, points, col, closed, thickness ); }
+	public inline function addConvexPolyFilled( points: hl.NativeArray<ImVec2>, col: ImU32 ) { add_convex_poly_filled(this, points, col ); }
+	public inline function addBezierCurve( p1: ImVec2, p2: ImVec2, p3: ImVec2, p4: ImVec2, col: ImU32, thickness: Single = 1.0, num_segments: Int = 0 ) { add_bezier_curve(this, p1, p2, p3, p4, col, thickness, num_segments ); }
+	//
+	public inline function addText( pos: ImVec2, col: ImU32, text: String ) { add_text(this, pos, col, text); }
+	public inline function addText2( font: ImFont, fontSize: Single, pos: ImVec2, col: ImU32, text: String, wrapWidth: Single = 0.0, ?cpuFineClipRect: ImVec4 ) { add_text2(this, font==null?null:(@:privateAccess font), fontSize, pos, col, text, wrapWidth, cpuFineClipRect); }
+
+	public inline function addImage( userTextureId: ImTextureID, pMin: ImVec2, pMax: ImVec2, ?uvMin: ImVec2, ?uvMax: ImVec2, col: Int = 0xffffffff ) { add_image(this, userTextureId, pMin, pMax, uvMin, uvMax, col); }
+	public inline function addImageQuad( userTextureId: ImTextureID, p1: ImVec2, p2: ImVec2, p3: ImVec2, p4: ImVec2, ?uv1: ImVec2, ?uv2: ImVec2, ?uv3: ImVec2, ?uv4: ImVec2, col: Int = 0xffffffff ) { add_image_quad(this, userTextureId, p1, p2, p3, p4, uv1, uv2, uv3, uv4, col); }
+	// Due to Haxe limitation on defualt parameters being "constant" and enum abstract values that rely on previous enum abstract value (A | B) are not "constant" - hack with -1
+	public inline function addImageRounded( userTextureId: ImTextureID, pMin: ImVec2, pMax: ImVec2, ?uvMin: ImVec2, ?uvMax: ImVec2, col: Int, rounding: Single, roundingCorners: ImDrawFlags = -1 ) { add_image_rounded(this, userTextureId, pMin, pMax, uvMin, uvMax, col, rounding, roundingCorners == -1 ? ImDrawFlags.RoundCornersDefault_ : roundingCorners); }
+
+	#if heaps
+	// Helper methods for Heaps: Use Tile instead of Texture to pass image segments easily.
+
+	public inline function addTile( tile: h2d.Tile, pMin: ImVec2, ?pMax: ImVec2, col: Int = 0xffffffff, honorDxDy = false) @:privateAccess {
+		if (pMax == null) pMax = ImTypeCache.vec2(pMin.x + tile.width, pMin.y + tile.height);
+		if (honorDxDy) {
+			pMin.x += tile.dx;
+			pMin.y += tile.dy;
+			pMax.x += tile.dx;
+			pMax.y += tile.dy;
+		}
+		addImage(tile.getTexture(), pMin, pMax, ImTypeCache.vec2(tile.u, tile.v), ImTypeCache.vec2(tile.u2, tile.v2), col);
+	}
+
+	public inline function addTileQuad( tile: h2d.Tile, p1: ImVec2, p2: ImVec2, p3: ImVec2, p4: ImVec2, col: Int = 0xffffffff) @:privateAccess {
+		addImageQuad( tile.getTexture(), p1, p2, p3, p4,
+			ImTypeCache.vec2(tile.u, tile.v), ImTypeCache.vec2(tile.u2, tile.v), ImTypeCache.vec2(tile.u2, tile.v2), ImTypeCache.vec2(tile.u2, tile.v),
+			col
+		);
+	}
+
+	public inline function addTileRounded( tile: h2d.Tile, pMin: ImVec2, ?pMax: ImVec2, col: Int, rounding: Single, roundingCorners: ImDrawFlags = -1, honorDxDy = false ) @:privateAccess {
+		if (pMax == null) pMax = ImTypeCache.vec2(pMin.x + tile.width, pMin.y + tile.height);
+		if (honorDxDy) {
+			pMin.x += tile.dx;
+			pMin.y += tile.dy;
+			pMax.x += tile.dx;
+			pMax.y += tile.dy;
+		}
+		addImageRounded( tile.getTexture(), pMin, pMax, ImTypeCache.vec2(tile.u, tile.v), ImTypeCache.vec2(tile.u2, tile.v2), col, rounding, roundingCorners);
+	}
+	#end
+
+	function push_clip_rect(clip_rect_min: ExtDynamic<ImVec2>, clip_rect_max: ExtDynamic<ImVec2>, intersect_with_current_clip_rect: Bool ) {}
+	function get_clip_rect_min(): ExtDynamic<ImVec2> { return null; }
+	function get_clip_rect_max(): ExtDynamic<ImVec2> { return null; }
+	
+	static function add_line( drawlist: ImDrawListPtr, p1: ExtDynamic<ImVec2>, p2: ExtDynamic<ImVec2>, col: ImU32, thickness: Single ) {}
+	static function add_rect( drawlist: ImDrawListPtr, pMin: ExtDynamic<ImVec2>, pMax: ExtDynamic<ImVec2>, col: ImU32, rounding: Single, roundingCorners: ImDrawFlags, thickness ) {}
+	static function add_rect_filled( drawlist: ImDrawListPtr, pMin: ExtDynamic<ImVec2>, pMax: ExtDynamic<ImVec2>, col: ImU32, rounding: Single, roundingCorners: ImDrawFlags ) {}
+	static function add_rect_filled_multicolor( drawlist: ImDrawListPtr, pMin: ExtDynamic<ImVec2>, pMax: ExtDynamic<ImVec2>, col_upr_left: ImU32, col_upr_right: ImU32, col_bot_right: ImU32, col_bot_left: ImU32 ) {}
+	static function add_quad( drawlist: ImDrawListPtr, p1: ExtDynamic<ImVec2>, p2: ExtDynamic<ImVec2>, p3: ExtDynamic<ImVec2>, p4: ExtDynamic<ImVec2>, col: ImU32, thickness: Single ) {}
+	static function add_quad_filled( drawlist: ImDrawListPtr, p1: ExtDynamic<ImVec2>, p2: ExtDynamic<ImVec2>, p3: ExtDynamic<ImVec2>, p4: ExtDynamic<ImVec2>, col: ImU32 ) {}
+	static function add_triangle( drawlist: ImDrawListPtr, p1: ExtDynamic<ImVec2>, p2: ExtDynamic<ImVec2>, p3: ExtDynamic<ImVec2>, col: ImU32, thickness: Single ) {}
+	static function add_triangle_filled( drawlist: ImDrawListPtr, p1: ExtDynamic<ImVec2>, p2: ExtDynamic<ImVec2>, p3: ExtDynamic<ImVec2>, col: ImU32 ) {}
+	static function add_circle( drawlist: ImDrawListPtr, center: ExtDynamic<ImVec2>, radius: Single, col: ImU32, num_segments: Int, thickness: Single ) {}
+	static function add_circle_filled( drawlist: ImDrawListPtr, center: ExtDynamic<ImVec2>, radius: Single, col: ImU32, num_segments: Int) {}
+	static function add_ngon( drawlist: ImDrawListPtr, center: ExtDynamic<ImVec2>, radius: Single, col: ImU32, num_segments: Int, thickness: Single ) {}
+	static function add_ngon_filled( drawlist: ImDrawListPtr, center: ExtDynamic<ImVec2>, radius: Single, col: ImU32, num_segments: Int) {}
+	static function add_poly_line( drawlist: ImDrawListPtr, points: hl.NativeArray<ImVec2>, col: ImU32, closed: Bool, thickness: Single ) {}
+	static function add_convex_poly_filled( drawlist: ImDrawListPtr, points: hl.NativeArray<ExtDynamic<ImVec2>>, col: ImU32 ) {}
+	static function add_bezier_curve( drawlist: ImDrawListPtr, p1: ExtDynamic<ImVec2>, p2: ExtDynamic<ImVec2>, p3: ExtDynamic<ImVec2>, p4: ExtDynamic<ImVec2>, col: ImU32, thickness: Single, num_segments: Int ) {}
+	static function add_text( drawlist: ImDrawListPtr, pos: ExtDynamic<ImVec2>, col: ImU32, text: String ) {}
+	static function add_text2( drawlist: ImDrawListPtr, font: ImFontPtr, font_size: Single, pos: ExtDynamic<ImVec2>, col: ImU32, text: String, wrap_width: Single, cpu_fine_clip_rect: ExtDynamic<ImVec4> ) {}
+
+	static function add_image( drawlist: ImDrawListPtr, userTextureId: ImTextureID, pMin: ExtDynamic<ImVec2>, pMax: ExtDynamic<ImVec2>, uvMin: ExtDynamic<ImVec2>, uvMax: ExtDynamic<ImVec2>, col: ImU32 ) {}
+	static function add_image_quad( drawlist: ImDrawListPtr, userTextureId: ImTextureID, p1: ExtDynamic<ImVec2>, p2: ExtDynamic<ImVec2>, p3: ExtDynamic<ImVec2>, p4: ExtDynamic<ImVec2>, uv1: ExtDynamic<ImVec2>, uv2: ExtDynamic<ImVec2>, uv3: ExtDynamic<ImVec2>, uv4: ExtDynamic<ImVec2>, col: ImU32 ) {}
+	static function add_image_rounded( drawlist: ImDrawListPtr, userTextureId: ImTextureID, pMin: ExtDynamic<ImVec2>, pMax: ExtDynamic<ImVec2>, uvMin: ExtDynamic<ImVec2>, uvMax: ExtDynamic<ImVec2>, col: ImU32, rounding: Single, roundingCorners: ImDrawFlags ) {}
+}

--- a/imgui/types/ImDrawList.hx
+++ b/imgui/types/ImDrawList.hx
@@ -8,45 +8,65 @@ import imgui.types.Pointers;
 abstract ImDrawList(ImDrawListPtr) from ImDrawListPtr to ImDrawListPtr
 {
 	public inline function new(ptr: ImDrawListPtr) { this = ptr; }
-  
-  // TODO: Migrate to ImVec2S/ImVec4S
+	
+	// Note: Because how HL interprets optional values (i.e. `_REF(_T)`)
+	// and default value given to them is silently ignored, instead providing a nullptr,
+	// all calls that have default values that are not nulls are inline wrappers.
 
-	public inline function pushClipRect(clipRectMin: ImVec2, clipRectMax: ImVec2, intersectWithCurrentClipRect: Bool = false) { push_clip_rect(clipRectMin, clipRectMax, intersectWithCurrentClipRect); }
-	public function pushClipRectFullScreen() {}
-	public function popClipRect() {}
-	public function pushTextureId(textureId: ImTextureID) {}
-	public function popTextureId() {}
-	public inline function getClipRectMin(): ImVec2 { return get_clip_rect_min(); }
-	public inline function getClipRectMax(): ImVec2 { return get_clip_rect_max(); }
+	public inline function pushClipRect(clipRectMin: ImVec2S, clipRectMax: ImVec2S, intersectWithCurrentClipRect: Bool = false) { push_clip_rect(clipRectMin, clipRectMax, intersectWithCurrentClipRect); }
+	public        function pushClipRectFullScreen() {}
+	public        function popClipRect() {}
+	public        function pushTextureId(textureId: ImTextureID) {}
+	public        function popTextureId() {}
+	public        function getClipRectMin(): ImVec2S { return null; }
+	public        function getClipRectMax(): ImVec2S { return null; }
 
-	public inline function addLine( p1: ImVec2, p2: ImVec2, col: ImU32, thickness: Single = 1.0 ) { add_line( this, p1, p2, col, thickness ); }
-	public inline function addRect( pMin: ImVec2, pMax: ImVec2, col: ImU32, rounding: Single = 0.0, roundingCorners: ImDrawFlags = ImDrawFlags.None, thickness: Single = 1.0 ) { add_rect( this, pMin, pMax, col, rounding, roundingCorners, thickness ); }
-	public inline function addRectFilled( pMin: ImVec2, pMax: ImVec2, col: ImU32, rounding: Single = 0.0, roundingCorners: ImDrawFlags = ImDrawFlags.None ) { add_rect_filled( this, pMin, pMax, col, rounding, roundingCorners); }
-	public inline function addRectFilledMultiColor( pMin: ImVec2, pMax: ImVec2, col_upr_left: ImU32, col_upr_right: ImU32, col_bot_right: ImU32, col_bot_left: ImU32 ) { add_rect_filled_multicolor( this, pMin, pMax, col_upr_left, col_upr_right, col_bot_right, col_bot_left ); }
-	public inline function addQuad( p1: ImVec2, p2: ImVec2, p3: ImVec2, p4: ImVec2, col: ImU32, thickness: Single = 1.0 ) { add_quad(this, p1, p2, p3, p4, col, thickness ); }
-	public inline function addQuadFilled( p1: ImVec2, p2: ImVec2, p3: ImVec2, p4: ImVec2, col: ImU32 ) { add_quad_filled( this, p1, p2, p3, p4, col ); }
-	public inline function addTriangle( p1: ImVec2, p2: ImVec2, p3: ImVec2, col: ImU32, thickness: Single = 1.0 ) { add_triangle(this, p1, p2, p3, col, thickness ); }
-	public inline function addTriangleFilled( p1: ImVec2, p2: ImVec2, p3: ImVec2, col: ImU32 ) { add_triangle_filled(this, p1, p2, p3, col ); }
-	public inline function addCircle( center: ImVec2, radius: Single, col: ImU32, num_segments: Int = 0, thickness: Single = 1.0 ) { add_circle( this, center, radius, col, num_segments, thickness ); }
-	public inline function addCircleFilled( center: ImVec2, radius: Single, col: ImU32, num_segments: Int = 0) { add_circle_filled(this, center, radius, col, num_segments ); }
-	public inline function addNgon( center: ImVec2, radius: Single, col: ImU32, num_segments: Int, thickness: Single = 1.0 ) { add_ngon(this, center, radius, col, num_segments, thickness ); }
-	public inline function addNgonFilled( center: ImVec2, radius: Single, col: ImU32, num_segments: Int = 0) { add_ngon_filled(this, center, radius, col, num_segments ); }
-	public inline function addPolyLine( points: hl.NativeArray<ImVec2>, col: ImU32, closed: Bool, thickness: Single = 1.0 ) { add_poly_line(this, points, col, closed, thickness ); }
-	public inline function addConvexPolyFilled( points: hl.NativeArray<ImVec2>, col: ImU32 ) { add_convex_poly_filled(this, points, col ); }
-	public inline function addBezierCurve( p1: ImVec2, p2: ImVec2, p3: ImVec2, p4: ImVec2, col: ImU32, thickness: Single = 1.0, num_segments: Int = 0 ) { add_bezier_curve(this, p1, p2, p3, p4, col, thickness, num_segments ); }
+	public inline function addLine( p1: ImVec2S, p2: ImVec2S, col: ImU32, thickness: Single = 1.0 ) { add_line( p1, p2, col, thickness ); }
+	public inline function addRect( pMin: ImVec2S, pMax: ImVec2S, col: ImU32, rounding: Single = 0.0, roundingCorners: ImDrawFlags = ImDrawFlags.None, thickness: Single = 1.0 ) { add_rect( pMin, pMax, col, rounding, roundingCorners, thickness ); }
+	public inline function addRectFilled( pMin: ImVec2S, pMax: ImVec2S, col: ImU32, rounding: Single = 0.0, roundingCorners: ImDrawFlags = ImDrawFlags.None ) { add_rect_filled( pMin, pMax, col, rounding, roundingCorners); }
+	public        function addRectFilledMultiColor( pMin: ImVec2S, pMax: ImVec2S, col_upr_left: ImU32, col_upr_right: ImU32, col_bot_right: ImU32, col_bot_left: ImU32 ) {}
+	public inline function addQuad( p1: ImVec2S, p2: ImVec2S, p3: ImVec2S, p4: ImVec2S, col: ImU32, thickness: Single = 1.0 ) { add_quad(p1, p2, p3, p4, col, thickness ); }
+	public        function addQuadFilled( p1: ImVec2S, p2: ImVec2S, p3: ImVec2S, p4: ImVec2S, col: ImU32 ) {}
+	public inline function addTriangle( p1: ImVec2S, p2: ImVec2S, p3: ImVec2S, col: ImU32, thickness: Single = 1.0 ) { add_triangle(p1, p2, p3, col, thickness ); }
+	public        function addTriangleFilled( p1: ImVec2S, p2: ImVec2S, p3: ImVec2S, col: ImU32 ) {}
+	public inline function addCircle( center: ImVec2S, radius: Single, col: ImU32, num_segments: Int = 0, thickness: Single = 1.0 ) { add_circle( center, radius, col, num_segments, thickness ); }
+	public inline function addCircleFilled( center: ImVec2S, radius: Single, col: ImU32, num_segments: Int = 0) { add_circle_filled(center, radius, col, num_segments ); }
+	public inline function addNgon( center: ImVec2S, radius: Single, col: ImU32, num_segments: Int, thickness: Single = 1.0 ) { add_ngon(center, radius, col, num_segments, thickness ); }
+	public inline function addNgonFilled( center: ImVec2S, radius: Single, col: ImU32, num_segments: Int = 0) { add_ngon_filled(center, radius, col, num_segments ); }
+	public inline function addPolyLine( points: hl.NativeArray<ImVec2S>, col: ImU32, closed: Bool, thickness: Single = 1.0 ) { add_poly_line(points, col, closed, thickness ); }
+	public        function addConvexPolyFilled( points: hl.NativeArray<ImVec2S>, col: ImU32 ) {}
+	public inline function addBezierCurve( p1: ImVec2S, p2: ImVec2S, p3: ImVec2S, p4: ImVec2S, col: ImU32, thickness: Single = 1.0, num_segments: Int = 0 ) { add_bezier_curve(p1, p2, p3, p4, col, thickness, num_segments ); }
 	//
-	public inline function addText( pos: ImVec2, col: ImU32, text: String ) { add_text(this, pos, col, text); }
-	public inline function addText2( font: ImFont, fontSize: Single, pos: ImVec2, col: ImU32, text: String, wrapWidth: Single = 0.0, ?cpuFineClipRect: ImVec4 ) { add_text2(this, font==null?null:(@:privateAccess font), fontSize, pos, col, text, wrapWidth, cpuFineClipRect); }
+	public        function addText( pos: ImVec2S, col: ImU32, text: String ) {}
+	public inline function addText2( font: ImFont, fontSize: Single, pos: ImVec2S, col: ImU32, text: String, wrapWidth: Single = 0.0, ?cpuFineClipRect: ImVec4S ) { add_text2(font, fontSize, pos, col, text, wrapWidth, cpuFineClipRect); }
 
-	public inline function addImage( userTextureId: ImTextureID, pMin: ImVec2, pMax: ImVec2, ?uvMin: ImVec2, ?uvMax: ImVec2, col: Int = 0xffffffff ) { add_image(this, userTextureId, pMin, pMax, uvMin, uvMax, col); }
-	public inline function addImageQuad( userTextureId: ImTextureID, p1: ImVec2, p2: ImVec2, p3: ImVec2, p4: ImVec2, ?uv1: ImVec2, ?uv2: ImVec2, ?uv3: ImVec2, ?uv4: ImVec2, col: Int = 0xffffffff ) { add_image_quad(this, userTextureId, p1, p2, p3, p4, uv1, uv2, uv3, uv4, col); }
-	// Due to Haxe limitation on defualt parameters being "constant" and enum abstract values that rely on previous enum abstract value (A | B) are not "constant" - hack with -1
-	public inline function addImageRounded( userTextureId: ImTextureID, pMin: ImVec2, pMax: ImVec2, ?uvMin: ImVec2, ?uvMax: ImVec2, col: Int, rounding: Single, roundingCorners: ImDrawFlags = -1 ) { add_image_rounded(this, userTextureId, pMin, pMax, uvMin, uvMax, col, rounding, roundingCorners == -1 ? ImDrawFlags.RoundCornersDefault_ : roundingCorners); }
+	public inline function addImage( userTextureId: ImTextureID, pMin: ImVec2S, pMax: ImVec2S, ?uvMin: ImVec2S, ?uvMax: ImVec2S, col: Int = 0xffffffff ) { add_image(userTextureId, pMin, pMax, uvMin, uvMax, col); }
+	public inline function addImageQuad( userTextureId: ImTextureID, p1: ImVec2S, p2: ImVec2S, p3: ImVec2S, p4: ImVec2S, ?uv1: ImVec2S, ?uv2: ImVec2S, ?uv3: ImVec2S, ?uv4: ImVec2S, col: Int = 0xffffffff ) { add_image_quad(userTextureId, p1, p2, p3, p4, uv1, uv2, uv3, uv4, col); }
+	public inline function addImageRounded( userTextureId: ImTextureID, pMin: ImVec2S, pMax: ImVec2S, uvMin: ImVec2S, uvMax: ImVec2S, col: Int, rounding: Single, roundingCorners: ImDrawFlags = RoundCornersDefault_ ) { add_image_rounded(userTextureId, pMin, pMax, uvMin, uvMax, col, rounding, roundingCorners); }
 
+	// Stateful path API, add points then finish with pathFillConvex() or pathStroke()
+
+	public        function pathClear() {}
+	public        function pathLineTo(pos: ImVec2S) {}
+	public        function pathLineToMergeDuplicate(pos: ImVec2S) {}
+	public        function pathFillConvex(col: Int) {}
+	public inline function pathStroke(col: Int, flags: ImDrawFlags = 0, thickness: Single = 1.0) { path_stroke(col, flags, thickness); }
+	              function path_stroke(col: Int, flags: ImDrawFlags, thickness: Single) {}
+	public inline function pathArcTo(center: ImVec2S, radius: Single, a_min: Single, a_max: Single, num_segments: Int = 0) { path_arc_to(center, radius, a_min, a_max, num_segments); }
+	              function path_arc_to(center: ImVec2S, radius: Single, a_min: Single, a_max: Single, num_segments: Int) {}
+	/* Use precomputed angles for a 12 steps circle */
+	public        function pathArcToFast(center: ImVec2S, radius: Single, a_min_of_12: Int, a_max_of_12: Int) {}
+	public inline function pathBezierCubicCurveTo(p2: ImVec2S, p3: ImVec2S, p4: ImVec2S, num_segments: Int = 0) { path_bezier_cubic_curve_to(p2, p3, p4, num_segments); }
+	              function path_bezier_cubic_curve_to(p2: ImVec2S, p3: ImVec2S, p4: ImVec2S, num_segments: Int) {}
+	public inline function pathBezierQuadraticCurveTo(p2: ImVec2S, p3: ImVec2S, num_segments: Int = 0) { path_bezier_quadratic_curve_to(p2, p3, num_segments); }
+	              function path_bezier_quadratic_curve_to(p2: ImVec2S, p3: ImVec2S, num_segments: Int) {}
+	public inline function pathRect(rect_min: ImVec2S, rect_max: ImVec2S, rounding: Single = 0.0, flags: ImDrawFlags = 0) { path_rect(rect_min, rect_max, rounding, flags); }
+	              function path_rect(rect_min: ImVec2S, rect_max: ImVec2S, rounding: Single, flags: ImDrawFlags) {}
+	
 	#if heaps
 	// Helper methods for Heaps: Use Tile instead of Texture to pass image segments easily.
 
-	public inline function addTile( tile: h2d.Tile, pMin: ImVec2, ?pMax: ImVec2, col: Int = 0xffffffff, honorDxDy = false) @:privateAccess {
+	public inline function addTile( tile: h2d.Tile, pMin: ImVec2S, ?pMax: ImVec2S, col: Int = 0xffffffff, honorDxDy = false) @:privateAccess {
 		if (pMax == null) pMax = ImTypeCache.vec2(pMin.x + tile.width, pMin.y + tile.height);
 		if (honorDxDy) {
 			pMin.x += tile.dx;
@@ -57,14 +77,14 @@ abstract ImDrawList(ImDrawListPtr) from ImDrawListPtr to ImDrawListPtr
 		addImage(tile.getTexture(), pMin, pMax, ImTypeCache.vec2(tile.u, tile.v), ImTypeCache.vec2(tile.u2, tile.v2), col);
 	}
 
-	public inline function addTileQuad( tile: h2d.Tile, p1: ImVec2, p2: ImVec2, p3: ImVec2, p4: ImVec2, col: Int = 0xffffffff) @:privateAccess {
+	public inline function addTileQuad( tile: h2d.Tile, p1: ImVec2S, p2: ImVec2S, p3: ImVec2S, p4: ImVec2S, col: Int = 0xffffffff) @:privateAccess {
 		addImageQuad( tile.getTexture(), p1, p2, p3, p4,
 			ImTypeCache.vec2(tile.u, tile.v), ImTypeCache.vec2(tile.u2, tile.v), ImTypeCache.vec2(tile.u2, tile.v2), ImTypeCache.vec2(tile.u2, tile.v),
 			col
 		);
 	}
 
-	public inline function addTileRounded( tile: h2d.Tile, pMin: ImVec2, ?pMax: ImVec2, col: Int, rounding: Single, roundingCorners: ImDrawFlags = -1, honorDxDy = false ) @:privateAccess {
+	public inline function addTileRounded( tile: h2d.Tile, pMin: ImVec2S, ?pMax: ImVec2S, col: Int, rounding: Single, roundingCorners: ImDrawFlags = -1, honorDxDy = false ) @:privateAccess {
 		if (pMax == null) pMax = ImTypeCache.vec2(pMin.x + tile.width, pMin.y + tile.height);
 		if (honorDxDy) {
 			pMin.x += tile.dx;
@@ -76,29 +96,23 @@ abstract ImDrawList(ImDrawListPtr) from ImDrawListPtr to ImDrawListPtr
 	}
 	#end
 
-	function push_clip_rect(clip_rect_min: ExtDynamic<ImVec2>, clip_rect_max: ExtDynamic<ImVec2>, intersect_with_current_clip_rect: Bool ) {}
-	function get_clip_rect_min(): ExtDynamic<ImVec2> { return null; }
-	function get_clip_rect_max(): ExtDynamic<ImVec2> { return null; }
+	function push_clip_rect(clip_rect_min: ImVec2S, clip_rect_max: ImVec2S, intersect_with_current_clip_rect: Bool ) {}
 	
-	static function add_line( drawlist: ImDrawListPtr, p1: ExtDynamic<ImVec2>, p2: ExtDynamic<ImVec2>, col: ImU32, thickness: Single ) {}
-	static function add_rect( drawlist: ImDrawListPtr, pMin: ExtDynamic<ImVec2>, pMax: ExtDynamic<ImVec2>, col: ImU32, rounding: Single, roundingCorners: ImDrawFlags, thickness ) {}
-	static function add_rect_filled( drawlist: ImDrawListPtr, pMin: ExtDynamic<ImVec2>, pMax: ExtDynamic<ImVec2>, col: ImU32, rounding: Single, roundingCorners: ImDrawFlags ) {}
-	static function add_rect_filled_multicolor( drawlist: ImDrawListPtr, pMin: ExtDynamic<ImVec2>, pMax: ExtDynamic<ImVec2>, col_upr_left: ImU32, col_upr_right: ImU32, col_bot_right: ImU32, col_bot_left: ImU32 ) {}
-	static function add_quad( drawlist: ImDrawListPtr, p1: ExtDynamic<ImVec2>, p2: ExtDynamic<ImVec2>, p3: ExtDynamic<ImVec2>, p4: ExtDynamic<ImVec2>, col: ImU32, thickness: Single ) {}
-	static function add_quad_filled( drawlist: ImDrawListPtr, p1: ExtDynamic<ImVec2>, p2: ExtDynamic<ImVec2>, p3: ExtDynamic<ImVec2>, p4: ExtDynamic<ImVec2>, col: ImU32 ) {}
-	static function add_triangle( drawlist: ImDrawListPtr, p1: ExtDynamic<ImVec2>, p2: ExtDynamic<ImVec2>, p3: ExtDynamic<ImVec2>, col: ImU32, thickness: Single ) {}
-	static function add_triangle_filled( drawlist: ImDrawListPtr, p1: ExtDynamic<ImVec2>, p2: ExtDynamic<ImVec2>, p3: ExtDynamic<ImVec2>, col: ImU32 ) {}
-	static function add_circle( drawlist: ImDrawListPtr, center: ExtDynamic<ImVec2>, radius: Single, col: ImU32, num_segments: Int, thickness: Single ) {}
-	static function add_circle_filled( drawlist: ImDrawListPtr, center: ExtDynamic<ImVec2>, radius: Single, col: ImU32, num_segments: Int) {}
-	static function add_ngon( drawlist: ImDrawListPtr, center: ExtDynamic<ImVec2>, radius: Single, col: ImU32, num_segments: Int, thickness: Single ) {}
-	static function add_ngon_filled( drawlist: ImDrawListPtr, center: ExtDynamic<ImVec2>, radius: Single, col: ImU32, num_segments: Int) {}
-	static function add_poly_line( drawlist: ImDrawListPtr, points: hl.NativeArray<ImVec2>, col: ImU32, closed: Bool, thickness: Single ) {}
-	static function add_convex_poly_filled( drawlist: ImDrawListPtr, points: hl.NativeArray<ExtDynamic<ImVec2>>, col: ImU32 ) {}
-	static function add_bezier_curve( drawlist: ImDrawListPtr, p1: ExtDynamic<ImVec2>, p2: ExtDynamic<ImVec2>, p3: ExtDynamic<ImVec2>, p4: ExtDynamic<ImVec2>, col: ImU32, thickness: Single, num_segments: Int ) {}
-	static function add_text( drawlist: ImDrawListPtr, pos: ExtDynamic<ImVec2>, col: ImU32, text: String ) {}
-	static function add_text2( drawlist: ImDrawListPtr, font: ImFontPtr, font_size: Single, pos: ExtDynamic<ImVec2>, col: ImU32, text: String, wrap_width: Single, cpu_fine_clip_rect: ExtDynamic<ImVec4> ) {}
+	function add_line( p1: ImVec2S, p2: ImVec2S, col: ImU32, thickness: Single ) {}
+	function add_rect( pMin: ImVec2S, pMax: ImVec2S, col: ImU32, rounding: Single, roundingCorners: ImDrawFlags, thickness ) {}
+	function add_rect_filled( pMin: ImVec2S, pMax: ImVec2S, col: ImU32, rounding: Single, roundingCorners: ImDrawFlags ) {}
+	function add_quad( p1: ImVec2S, p2: ImVec2S, p3: ImVec2S, p4: ImVec2S, col: ImU32, thickness: Single ) {}
+	function add_triangle( p1: ImVec2S, p2: ImVec2S, p3: ImVec2S, col: ImU32, thickness: Single ) {}
+	function add_circle( center: ImVec2S, radius: Single, col: ImU32, num_segments: Int, thickness: Single ) {}
+	function add_circle_filled( center: ImVec2S, radius: Single, col: ImU32, num_segments: Int) {}
+	function add_ngon( center: ImVec2S, radius: Single, col: ImU32, num_segments: Int, thickness: Single ) {}
+	function add_ngon_filled( center: ImVec2S, radius: Single, col: ImU32, num_segments: Int) {}
+	function add_poly_line( points: hl.NativeArray<ImVec2S>, col: ImU32, closed: Bool, thickness: Single ) {}
+	function add_bezier_curve( p1: ImVec2S, p2: ImVec2S, p3: ImVec2S, p4: ImVec2S, col: ImU32, thickness: Single, num_segments: Int ) {}
+	
+	function add_text2( font: ImFontPtr, font_size: Single, pos: ImVec2S, col: ImU32, text: String, wrap_width: Single, cpu_fine_clip_rect: ImVec4S ) {}
 
-	static function add_image( drawlist: ImDrawListPtr, userTextureId: ImTextureID, pMin: ExtDynamic<ImVec2>, pMax: ExtDynamic<ImVec2>, uvMin: ExtDynamic<ImVec2>, uvMax: ExtDynamic<ImVec2>, col: ImU32 ) {}
-	static function add_image_quad( drawlist: ImDrawListPtr, userTextureId: ImTextureID, p1: ExtDynamic<ImVec2>, p2: ExtDynamic<ImVec2>, p3: ExtDynamic<ImVec2>, p4: ExtDynamic<ImVec2>, uv1: ExtDynamic<ImVec2>, uv2: ExtDynamic<ImVec2>, uv3: ExtDynamic<ImVec2>, uv4: ExtDynamic<ImVec2>, col: ImU32 ) {}
-	static function add_image_rounded( drawlist: ImDrawListPtr, userTextureId: ImTextureID, pMin: ExtDynamic<ImVec2>, pMax: ExtDynamic<ImVec2>, uvMin: ExtDynamic<ImVec2>, uvMax: ExtDynamic<ImVec2>, col: ImU32, rounding: Single, roundingCorners: ImDrawFlags ) {}
+	function add_image( userTextureId: ImTextureID, pMin: ImVec2S, pMax: ImVec2S, uvMin: ImVec2S, uvMax: ImVec2S, col: ImU32 ) {}
+	function add_image_quad( userTextureId: ImTextureID, p1: ImVec2S, p2: ImVec2S, p3: ImVec2S, p4: ImVec2S, uv1: ImVec2S, uv2: ImVec2S, uv3: ImVec2S, uv4: ImVec2S, col: ImU32 ) {}
+	function add_image_rounded( userTextureId: ImTextureID, pMin: ImVec2S, pMax: ImVec2S, uvMin: ImVec2S, uvMax: ImVec2S, col: ImU32, rounding: Single, roundingCorners: ImDrawFlags ) {}
 }

--- a/imgui/types/ImFont.hx
+++ b/imgui/types/ImFont.hx
@@ -1,0 +1,11 @@
+package imgui.types;
+
+import imgui.types.Pointers;
+
+@:hlNative("hlimgui")
+abstract ImFont(ImFontPtr) from ImFontPtr to ImFontPtr
+{
+	public inline function new(ptr: ImFontPtr) { this = ptr; }
+	
+	// TODO: Expose API
+}

--- a/imgui/types/ImFontAtlas.hx
+++ b/imgui/types/ImFontAtlas.hx
@@ -1,0 +1,142 @@
+package imgui.types;
+
+import imgui.ImGui;
+import hl.NativeArray;
+import hl.Bytes;
+import imgui.types.Pointers;
+import imgui.ImGui.ImVec2;
+
+@:build(imgui._ImGuiInternalMacro.buildFlatStruct())
+@:struct class ImFontConfig {
+	@:noCompletion var FontData: Bytes;                    // TTF/OTF data
+	var FontDataSize: Int;                  // TTF/OTF data size
+	var FontDataOwnedByAtlas: Bool;         // Force-set to false when adding from memory because GC.
+	var FontNo: Int;                        // Index of font within TTF/OTF file
+	var SizePixels: Single;                 // Size in pixels for rasterizer (more or less maps to the resulting font height).
+	var OversampleH: Int;                   // Rasterize at higher quality for sub-pixel positioning. Note the difference between 2 and 3 is minimal so you can reduce this to 2 to save memory. Read https://github.com/nothings/stb/blob/master/tests/oversample/README.md for details.
+	var OversampleV: Int;                   // Rasterize at higher quality for sub-pixel positioning. This is not really useful as we don't use sub-pixel positions on the Y axis.
+	var PixelSnapH: Bool;                   // Align every glyph to pixel boundary. Useful e.g. if you are merging a non-pixel aligned font with the default font. If enabled, you can set OversampleH/V to 1.
+	@:flatten var GlyphExtraSpacing: ImVec2;// Extra spacing (in pixels) between glyphs. Only X axis is supported for now.
+	@:flatten var GlyphOffset: ImVec2;      // Offset all glyphs from this font input.
+	@:noCompletion var GlyphRanges: Bytes;  // Pointer to a user-provided list of Unicode range (2 value per range, values are inclusive, zero-terminated list). THE ARRAY DATA NEEDS TO PERSIST AS LONG AS THE FONT IS ALIVE.
+	var GlyphMinAdvanceX: Single;           // Minimum AdvanceX for glyphs, set Min to align font icons, set both Min/Max to enforce mono-space font
+	var GlyphMaxAdvanceY: Single;           // Maximum AdvanceX for glyphs
+	var MergeMode: Bool;                    // Merge into previous ImFont, so you can combine multiple inputs font into one ImFont (e.g. ASCII font + icons + Japanese glyphs). You may want to use GlyphOffset.y when merge font of different heights.
+	var FontBuilderFlags: Int;              // Settings for custom font builder. THIS IS BUILDER IMPLEMENTATION DEPENDENT. Leave as zero if unsure.
+	var RasterizerMultiply: Single;         // Brighten (>1.0f) or darken (<1.0f) font output. Brightening small fonts may be a good workaround to make them more readable.
+	var EllipsisChar: hl.UI16;              // Explicitly specify unicode codepoint of ellipsis character. When fonts are being merged first specified ellipsis will be used.
+
+	public function new() {
+		init(this);
+	}
+	
+	// Helper methods for some quick configs
+	public inline function setOversample(h: Int = 3, v: Int = 1) {
+		this.OversampleH = h;
+		this.OversampleV = v;
+		return this;
+	}
+	public inline function setPixelSnapH(v: Bool = true) {
+		this.PixelSnapH = v;
+		return this;
+	}
+	public inline function setMergeMode(v: Bool = true) {
+		this.MergeMode = v;
+		return this;
+	}
+	
+	@:hlNative("hlimgui", "imfontconfig_init")
+	static function init(cfg: ImFontConfig) {}
+
+}
+/** An output storage for ImFontAtlas.getTexDataAsX methods. **/
+class ImFontTexData {
+	public var buffer: Bytes;
+	public var width: Int;
+	public var height: Int;
+	public var bytesPerPixel: Int;
+	
+	public function new() {}
+}
+
+/**
+	An output storage for ImFontAtlas.getMouseCursorTexData method.
+	
+	ImGui bundled cursor consist of cursor outline and fill, both are monochrome same color.
+	
+	In order to properly render the cursor, do the following:
+	
+	NOTE: This is how ImGui renders it, for some rerason `uvFill` and `uvBorder` are flipped!
+	
+	* Shadow color is black with 18.82% (0x30) alpha.
+	* Border color is black.
+	* Fill color is white.
+	* Full size of the cursor is `size + [2,0]` to account for shadow.
+	
+	0. If you render on-screen, offset the drawing position by `-offset` to properly position the cursor pivot.
+	1. Draw `uvFill` offset by [1,0] with shadow color
+	2. Draw `uvFill` offset by [2,0] with shadow color
+	3. Draw `uvFill` with border color
+	4. Draw `uvBorder` with fill color
+	
+**/
+class ImCursorData {
+	public var offset: ImVec2S;
+	public var size: ImVec2S;
+	public var uvBorder: ImVec4S; // xy = min, zw = max
+	public var uvFill: ImVec4S; // xy = min, zw = max
+	
+	public function new() {
+		offset = ImVec2S.get();
+		size = ImVec2S.get();
+		uvBorder = ImVec4S.get();
+		uvFill = ImVec4S.get();
+	}
+}
+
+@:struct class ImFontAtlasCustomRect {
+	
+	public var width: hl.UI16;
+	public var height: hl.UI16;
+	public var x: hl.UI16;
+	public var y: hl.UI16;
+	public var glyphId: Int;
+	public var glyphAdvanceX: Single;
+	public var glyphOffsetX: Single; // ImVec2
+	public var glyphOffsetY: Single; // ImVec2
+	public var font: ImFont;
+	
+	public inline function isPacked(): Bool { return x != 0xffff; }
+}
+
+@:hlNative("hlimgui", "imfontatlas_")
+abstract ImFontAtlas(ImFontAtlasPtr) from ImFontAtlasPtr to ImFontAtlasPtr
+{
+	inline function new(ptr: ImFontAtlasPtr) { this = ptr; }
+	
+	public function addFont(config: ImFontConfig): ImFontPtr { return null; }
+	public function addFontDefault(?config: ImFontConfig): ImFontPtr { return null; }
+	public function addFontFromFileTTF(filename: String, size_pixels: Single, ?font_cfg: ImFontConfig, ?glyph_ranges: hl.NativeArray<hl.UI16>): ImFontPtr { return null; }
+	public function addFontFromMemoryTTF(font_data: Bytes, font_size: Int, size_pixels: Single, ?font_cfg: ImFontConfig, ?glyph_ranges: hl.NativeArray<hl.UI16>): ImFontPtr { return null; }
+	
+	public function clearInputData() {}
+	public function clearTexData() {}
+	public function clearFonts() {}
+	public function clear() {}
+	public function build(): Bool { return false; }
+	
+	public function getTexDataAsAlpha8(output: ImFontTexData) {}
+	public function getTexDataAsRGBA32(output: ImFontTexData) {}
+	public function isBuilt(): Bool { return false; }
+	public function setTexId(id: ImTextureID) {}
+	
+	// GetGlyphRangesX
+	
+	public function addCustomRectRegular(width: Int, height: Int): Int { return 0; }
+	public function addCustomRectFontGlyph(font: ImFontPtr, id: hl.UI16, width: Int, height: Int, advance_x: Single, offset: ImVec2S = null): Int { return 0; }
+	public function getCustomRectByIndex(index: Int): ImFontAtlasCustomRect { return null; }
+	
+	public function calcCustomRectUV(rect: ImFontAtlasCustomRect, uv_min: ImVec2S, uv_max: ImVec2S) {}
+	public function getMouseCursorTexData(cursor: ImGuiMouseCursor, output: ImCursorData): Bool { return false; }
+	
+}

--- a/imgui/types/Pointers.hx
+++ b/imgui/types/Pointers.hx
@@ -1,0 +1,5 @@
+package imgui.types;
+
+// General Ptr storage
+typedef ImFontPtr = hl.Abstract<"imfont">;
+typedef ImFontAtlasPtr = hl.Abstract<"imfontatlas">;

--- a/imgui/types/Pointers.hx
+++ b/imgui/types/Pointers.hx
@@ -3,3 +3,8 @@ package imgui.types;
 // General Ptr storage
 typedef ImFontPtr = hl.Abstract<"imfont">;
 typedef ImFontAtlasPtr = hl.Abstract<"imfontatlas">;
+typedef ImDrawListPtr = hl.Abstract<"imdrawlist">;
+typedef ImStateStoragePtr = hl.Abstract<"imstatestorage">;
+typedef ImContextPtr = hl.Abstract<"imcontext">;
+typedef ImDragDropPayloadPtr = hl.Abstract<"imdnd">;
+typedef ImGuiDockNode = hl.Abstract<"imguidocknode">;


### PR DESCRIPTION
* Reimplemented the ImFont handling: Now works with ImFontAtlas directly and most methods are accessible.
* Deprecated old APIs. 
* Extended ImDrawList API
* Added ImVecS - a not-dynamic ImVec variant that is better than dynamic ImVec
* ImFontAtlas and ImDrawList now use ImVecS variants. 
* Added ImTypeCache helper - rotation-based ImVec2/ImVec4 with 10 slots for quick reuse.
* Minor refactor: Moved multiple classes into separate files for better management (more to come)