### PR TITLE
Add a haxelib run command to build and copy hlimgui.hdll

### DIFF
--- a/Run.hx
+++ b/Run.hx
@@ -1,0 +1,26 @@
+import sys.io.File;
+
+class Run {
+
+
+	static inline final HLIMGUI_HDLL = "hlimgui.hdll";
+
+	static function main() {
+		var args = Sys.args();
+
+		var originalPath = args.pop();
+		var haxelibPath = Sys.getCwd();
+
+        switch( args.shift() ) {
+            case "build":
+                Sys.command("git submodule init");
+                Sys.command("git submodule update");
+                Sys.command("cd extension");
+                Sys.command("mkdir build");
+                Sys.command("cd build");
+                Sys.command("cmake ..");
+                Sys.command("cmake --build .");
+                File.copy(haxelibPath+"/"+HLIMGUI_HDLL,originalPath+"/"+HLIMGUI_HDLL);
+            }
+    }
+}

--- a/haxelib.json
+++ b/haxelib.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "license": "Public",
   "releasenote": "initial release",
+  "main" : "Run",
   "contributors": [
     "haddock7",
     "austineast"


### PR DESCRIPTION
Hi
This commit add a command to build and copy the hlimgui.hdll to the user's project the command is `haxelib run hlimgui build`
If this PR is accepted, may be update README.md to propose this new way to build and install.
