### PR TITLE
Add `haxelib run` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,22 @@
 # Heaps/HashLink native binding for [Dear ImGui](https://github.com/ocornut/imgui)
 
 ## Build & Install
-First, make sure that HashLink, CMake and a C/C++ compiler are installed on your system. This version of hlimgui uses submodules. Get them prepared like this:
+First, make sure that HashLink, CMake and a C/C++ compiler are installed on your system.
+
+### Building extension automatically
+1. Install the library to haxelib.
+  - With haxelib directly: `haxelib git hlimgui https://github.com/nspitko/hlimgui.git`
+  - By cloning it to another directory and using `haxelib dev hlimgui path/to/hlimgui`
+  - With lix: See https://github.com/lix-pm/lix.client#local-development
+2. Make sure your `hl.exe` is in the `PATH` or one of the following environment variables point at the directory where it's located.
+3. Run `haxelib run hlimgui build -u` to update submodules (`-u` flag) and compile the .hdll file.
+4. Add `-lib hlimgui` to your `build.hxml`
+5. When shipping, make sure to copy the `hlimgui.hdll` from hashlink directory or run `haxelib run hlimgui install path/to/output/dir`
+
+Note: by default `build` command compiles in debug mode, use `-r` flag to compile in release mode.
+
+### Building extension manually
+This version of hlimgui uses submodules. Get them prepared like this:
 
 ```
 git submodule init
@@ -48,10 +63,10 @@ Here is a list of unsupported features and changes:
 - The function `setIniFilename` doesn't exist in ImGui, it has been added to modify the filename of the default ini file saved by ImGui (pass null to turn off this feature).
 
 ## References
-Input function often take a `Ref<T>` / `imgui.FieldRef<T>` argument.
-Those are equivalent to `hl.Ref` however offer an extra feature of referencing an class instance or static field, not only local variables.
+Input functions often take a `Ref<T>` / `imgui.FieldRef<T>` argument.
+Those are equivalent to `hl.Ref` however offer an extra feature of referencing a class instance or static field, not only local variables.
 
-However the limitation of `Ref` is that it does not work properties (`get_x` / `set_y`), in which case you will have to manually load said values into local variables or use the wrapper function:
+However the limitation of `Ref` is that it does not work on properties (`get_x` / `set_y`), in which case you will have to manually load said values into local variables or use the wrapper function:
 ```haxe
 import imgui.ImGuiMacro.*; // Import the `wref` / `wrefv` and `wrefc` macro functions into global scope.
 // In order to denote which values should be converted into a reference,

--- a/Run.hx
+++ b/Run.hx
@@ -1,0 +1,157 @@
+import haxe.io.Path;
+import sys.FileSystem;
+import sys.io.File;
+using StringTools;
+
+typedef Command = {
+	var name: String;
+	@:optional var args: String;
+	var help: String;
+	function exec(args: Array<String>, flags: Array<String>): Void;
+}
+
+class Run {
+	
+	static inline final HLIMGUI_HDLL = "hlimgui.hdll";
+	
+	static var libPath: String = Sys.getCwd();
+	static var callPath: String;
+	
+	static var linearCommands: Array<Command> = [
+		{
+			name: "update",
+			help: "Update the git submodules",
+			exec: (_, _) -> {
+				Sys.println("Updating submodules...");
+				Sys.command("git", ["submodule", "init"]);
+				Sys.command("git", ["submodule", "update"]);
+			}
+		},
+		{
+			name: "build",
+			args: "[flags] [hdll_path]",
+			help: "Build the extension hdll file.
+    Flags:
+      \u001B[93m-u  | --update\u001B[0m      Update the git submodules (equivalent to running `haxelib run hlimgui update` beforehand)
+      \u001B[93m-r  | --release\u001B[0m     Build with Release configuration, defaults to Debug.
+      \u001B[93m-ni | --no-install\u001B[0m  Do not run the `install` command after build finished.
+    Args:
+      \u001B[93m[hdll_path]\u001B[0m         See the `install [output]` argument description.",
+			exec: function(args: Array<String>, flags: Array<String>) {
+				
+				if (flags.contains("-u") || flags.contains("--update")) commands["update"].exec([], []);
+				
+				Sys.println("Building the extension...");
+				if (!FileSystem.isDirectory("extension/build")) FileSystem.createDirectory("extension/build");
+				Sys.setCwd(Path.join([libPath, "extension", "build"]));
+				Sys.command("cmake", [".."]);
+				var buildArgs = ["--build", "."];
+				if (flags.contains("-r") || flags.contains("--release")) {
+					buildArgs.push("--config");
+					buildArgs.push("Release");
+				}
+				Sys.command("cmake", buildArgs);
+				Sys.setCwd(libPath);
+				
+				if (!flags.contains("-n") && !flags.contains("--no-install")) {
+					commands["install"].exec(args, []);
+				}
+			}
+		},
+		{
+			name: "install",
+			args: "[output]",
+			help: "Copy the .hdll file to [output] or hl.exe location
+    Args:
+      \u001B[93m[output]\u001B[0m            The directory to which copy the generated .hdll file.
+                          If not given, will try to copy it to the location of `hl.exe` by
+                          looking for it `HASHLINK_BIN`, `HASHLINK_PATH` and `HASHLINKPATH`
+                          environment variables, then in `PATH`.",
+			exec: (args, _) -> {
+				final hdllPath = Path.join([libPath, HLIMGUI_HDLL]);
+				if (!FileSystem.exists(hdllPath)) {
+					Sys.println("Extension is not built or failed to produce the .hdll file! Use `build` command.");
+					return;
+				}
+				var outputPath = null;
+				if (args.length == 0) {
+					outputPath = Sys.getEnv("HASHLINK_BIN") ?? Sys.getEnv("HASHLINK_PATH") ?? Sys.getEnv("HASHLINKPATH");
+					if (outputPath == null) {
+						for (dir in Sys.getEnv("PATH").split(";")) {
+							if (FileSystem.exists(Path.join([dir, "hl.exe"]))) {
+								outputPath = dir;
+								break;
+							}
+						}
+					}
+					if (outputPath == null) Sys.println("Warning: Could not locate hl.exe, .hdll file won't be copied for easy access!");
+				} else {
+					outputPath = args.shift();
+					if (!Path.isAbsolute(outputPath)) outputPath = Path.join([callPath, outputPath]); // Make sure . / .. paths resolve correctly
+				}
+				if (outputPath != null) {
+					if (!FileSystem.isDirectory(outputPath)) FileSystem.createDirectory(outputPath);
+					File.copy(hdllPath, Path.join([outputPath, HLIMGUI_HDLL]));
+					Sys.println("Copying file to " + outputPath);
+				}
+			}
+		},
+		{
+			name: "help",
+			args: "[command]",
+			help: "Print this text
+    Args:
+      \u001B[93mcommand\u001B[0m             Only print help for specific command.",
+			exec: (args, _) -> help(args)
+		}
+	];
+	static var commands: Map<String, Command> = [
+		for (cmd in linearCommands) cmd.name => cmd
+	];
+	
+	static function main() {
+		var args = Sys.args();
+		callPath = args.pop();
+		
+		var flags: Array<String> = [];
+		var i = 0;
+		while (i < args.length) {
+			if (args[i].charCodeAt(0) == '-'.code) {
+				flags.push(args[i].toLowerCase());
+				args.splice(i, 1);
+			} else i++;
+		}
+		
+		if (args.length == 0) {
+			help(args);
+			return;
+		}
+		var commandName = args.shift();
+		var command = commands[commandName];
+		if (command == null) {
+			Sys.println('Unknown command: ${commandName}');
+			help(args);
+			return;
+		}
+		
+		command.exec(args, flags);
+	}
+	
+	static function help(args: Array<String>) {
+		if (args.length > 0) {
+			var cmd = commands[args[0]];
+			if (cmd == null) {
+				Sys.println("Help not found for command \"" + args[0] + "\", no such command!");
+			} else {
+				Sys.println('Usage: haxelib run hlimgui \u001B[94m${cmd.name} \u001B[93m${cmd.args}\u001B[0m');
+				Sys.println(("  \u001B[94m" + cmd.name + "\u001B[93m " + (cmd.args ?? "")).rtrim() + "\u001B[0m - " + cmd.help);
+			}
+			return;
+		}
+		Sys.println("Usage: haxelib run hlimgui \u001B[94m<command> \u001B[93m<args>\u001B[0m");
+		Sys.println("Available commands:");
+		for (cmd in linearCommands) {
+			Sys.println(("  \u001B[94m" + cmd.name + "\u001B[93m " + (cmd.args ?? "")).rtrim() + "\u001B[0m - " + cmd.help);
+		}
+	}
+}

--- a/haxelib.json
+++ b/haxelib.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "license": "Public",
   "releasenote": "initial release",
+  "main": "Run",
   "contributors": [
     "haddock7",
     "austineast"


### PR DESCRIPTION
Add the `haxelib run hlimgui` support with the following commands:
* `update` - updates the git submodules
* `build` - build the .hdll file and runs `install` command. Has an option to run `update` beforehand, as well as compile in release mode.
* `install` copies the .hdll to given path OR copies it to hl.exe directory. 
* `help` prints usage details.

Updated readme with new instructions. @nspitko I'm not sure how it'd work with `haxeshim`, so try it first before merge.

This PR supersedes #23, as it offers more control over the build process.
To achieve same behavior as #23, use `haxelib run hlimgui build -u .` (`-u` for submodules and `.` to copy to the directory `run` was called from, otherwise it'll copy it near `hl.exe`)

Github automation:
close #23