### PR TITLE
macro: skip adding APublic to the field if it's explicitly private

### DIFF
--- a/imgui/_ImGuiInternalMacro.hx
+++ b/imgui/_ImGuiInternalMacro.hx
@@ -84,7 +84,7 @@ class _ImGuiInternalMacro {
         }
       }
       if (!flattened) {
-        if (!field.access.contains(APublic) && !field.access.contains(AStatic)) field.access.push(APublic);
+        if (!field.access.contains(APublic) && !field.access.contains(APrivate) && !field.access.contains(AStatic)) field.access.push(APublic);
         nfields.push(field);
       }
     }


### PR DESCRIPTION
related to https://github.com/nspitko/hlimgui/pull/34
i made a mistake of not checking if things still worked after making `__placeholder` private 😅
this fixes the conflict caused by macro adding APublic to a field that already has APrivate