### PR TITLE
Undefine hl.h's _GUID to fix a Windows build error

### DIFF
--- a/extension/imgui_config.h
+++ b/extension/imgui_config.h
@@ -72,6 +72,7 @@
 // #include "../utils.h"
 
 #include <hl.h>
+#undef _GUID
 #include "types.h"
 
 #define IM_VEC2_CLASS_EXTRA                                                 \


### PR DESCRIPTION
hl.h defining _GUID as "g" caused a bunch of build errors on my side. This change appears to fully fix that.